### PR TITLE
More lenient tests for successful requests

### DIFF
--- a/protocol/converted/test_3-3.feature
+++ b/protocol/converted/test_3-3.feature
@@ -43,7 +43,7 @@ Feature: Check that Bob can only append to Basic Container when he is authorized
     And header Content-Type = 'application/sparql-update'
     And request 'INSERT DATA { <> a <http://example.org/Foo> . }'
     When method PATCH
-    Then match [200, 204, 205] contains responseStatus
+    Then match [200, 201, 204, 205] contains responseStatus
 
   Scenario: Test 3.6 Write to container (PATCH) with delete denied
     Given url requestUri

--- a/protocol/converted/test_3-5.feature
+++ b/protocol/converted/test_3-5.feature
@@ -43,7 +43,7 @@ Feature: Check that Bob can read and append to Basic Container when he is author
     And header Content-Type = 'application/sparql-update'
     And request 'INSERT DATA { <> a <http://example.org/Foo> . }'
     When method PATCH
-    Then match [200, 204, 205] contains responseStatus
+    Then match [200, 201, 204, 205] contains responseStatus
 
   Scenario: Test 5.6 Write to container (PATCH) with delete denied
     Given url requestUri

--- a/protocol/converted/test_4-3.feature
+++ b/protocol/converted/test_4-3.feature
@@ -61,7 +61,7 @@ Feature: Check that Bob can only append to RDF resource when he is authorized ap
     And header Content-Type = 'text/turtle'
     And request '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>. <> rdfs:comment "Bob added this."     '
     When method POST
-    Then status 204
+    Then match [200, 204, 205] contains responseStatus
 
   Scenario: Test 3.8 Delete resource denied
     Given url requestUri

--- a/protocol/converted/test_4-7.feature
+++ b/protocol/converted/test_4-7.feature
@@ -61,7 +61,7 @@ Feature: Check that Bob can read and write to RDF resource when he is authorized
     And header Content-Type = 'text/turtle'
     And request '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>. <> rdfs:comment "Bob added this."     '
     When method POST
-    Then status 204
+    Then match [200, 204, 205] contains responseStatus
 
 #  Scenario: Test 7.8 on URL /alice_share_bob.ttl
 ##    Given url requestUri

--- a/protocol/converted/test_5-3.feature
+++ b/protocol/converted/test_5-3.feature
@@ -53,7 +53,7 @@ Feature: Check that Bob can only append to Non-RDF resource when he is authorize
     And header Content-Type = 'text/plain'
     And request "Bob's addition"
     When method POST
-    Then status 204
+    Then match [200, 204, 205] contains responseStatus
 
   Scenario: Test 3.7 Delete resource denied
     Given url requestUri

--- a/protocol/converted/test_5-5.feature
+++ b/protocol/converted/test_5-5.feature
@@ -53,7 +53,7 @@ Feature: Check that Bob can read and append to Non-RDF resource when he is autho
     And header Content-Type = 'text/plain'
     And request "Bob's addition"
     When method POST
-    Then status 204
+    Then match [200, 204, 205] contains responseStatus
 
   Scenario: Test 5.7 Delete resource denied
     Given url requestUri

--- a/protocol/converted/test_5-7.feature
+++ b/protocol/converted/test_5-7.feature
@@ -53,7 +53,7 @@ Feature: Check that Bob can read and write to Non-RDF resource when he is author
     And header Content-Type = 'text/plain'
     And request "Bob's addition"
     When method POST
-    Then status 204
+    Then match [200, 204, 205] contains responseStatus
 
 #  Scenario: Test 7.7 on URL /alice_share_bob.txt
 #    Given url requestUri


### PR DESCRIPTION
This allows more successful codes for several `PATCH` and `POST` operations. This is somewhat assuming that the conclusion of https://github.com/solid/specification/issues/288 is that we do not define status codes for everything, but I think these are a few cases where it is OK to accept more successful codes. 