### PR TITLE
Test for slash semantics exclusion

### DIFF
--- a/protocol/solid-protocol-spec.ttl
+++ b/protocol/solid-protocol-spec.ttl
@@ -13,7 +13,8 @@
     spec:requirement <https://solidproject.org/TR/protocol#sr-http-content-type>,
                    <https://solidproject.org/TR/protocol#resource-representations>,
                    <https://solidproject.org/TR/protocol#writing-resources>,
-                   <https://solidproject.org/TR/protocol#web-access-control>
+                   <https://solidproject.org/TR/protocol#web-access-control>,
+                       <https://solidproject.org/TR/protocol#sr-uri-trailing-slash-distinct>
 .
 
 <https://solidproject.org/TR/protocol#sr-http-content-type>

--- a/protocol/solid-protocol-spec.ttl
+++ b/protocol/solid-protocol-spec.ttl
@@ -25,6 +25,16 @@
   spec:statement "A Solid server MUST reject PUT, POST and PATCH requests without the Content-Type header with a status code of 400."
 .
 
+<https://solidproject.org/TR/protocol#sr-uri-trailing-slash-distinct>
+  a spec:NormativeRequirement ;
+  spec:requirementSubject spec:Server ;
+  spec:requirementLevel spec:MUST ;
+  schema:name "No two resources differing only by trailing slash" ;
+  schema:description "Full text of the specification section" ;
+    spec:statement "If two URIs differ only in the trailing slash, and the server has associated a resource with one of them, then the other URI MUST NOT correspond to another resource"
+.
+
+
 <https://solidproject.org/TR/protocol#resource-representations>
   a spec:NormativeRequirement ;
   schema:name "Resource Representations" ;

--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -14,6 +14,14 @@ manifest:content-type-reject
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/writing-resource/content-type-reject.feature> .
 
+manifest:slash-semantics-exclude
+  a td:TestCase ;
+    spec:requirementReference <https://solidproject.org/TR/protocol#sr-uri-trailing-slash-distinct> ,
+    <https://solidproject.org/TR/protocol#sr-uri-redirect-differing> ;
+  td:reviewStatus td:unreviewed ;
+  spec:testScript
+    <https://github.com/solid/specification-tests/protocol/writing-resource/slash-semantics-exclude.feature> .
+
 manifest:content-negotiation-jsonld
   a td:TestCase ;
   spec:requirementReference <https://solidproject.org/TR/protocol#resource-representations> ;

--- a/protocol/writing-resource/slash-semantics-exclude.feature
+++ b/protocol/writing-resource/slash-semantics-exclude.feature
@@ -1,0 +1,60 @@
+Feature: With and without trailing slash cannot co-exist
+
+  Background: Set up clients and paths
+    * def testContainer = createTestContainer()
+    * def resource = testContainer.generateChildResource('/foo')
+
+  Scenario: PUT container, then try resource with same name
+    * def childContainerUrl = testContainer.getUrl() + 'foo/'
+    Given url childContainerUrl
+    And configure headers = clients.alice.getAuthHeaders('PUT', childContainerUrl)
+    When method PUT
+    Then assert responseStatus >= 200 && responseStatus < 300
+
+    * def resourceUrl = resource.getUrl()
+    Given url resourceUrl
+    And configure headers = clients.alice.getAuthHeaders('GET', resourceUrl)
+    When method GET
+    Then match [301, 404, 410] contains responseStatus
+
+    * def resourceUrl = resource.getUrl()
+    Given url resourceUrl
+    And configure headers = clients.alice.getAuthHeaders('PUT', resourceUrl)
+    And request "Hello"
+    When method PUT
+     # See https://www.rfc-editor.org/rfc/rfc7231.html#page-27 for why 409 or 415
+    Then match [409, 415] contains responseStatus
+
+
+    
+    
+  Scenario: PUT resource, then try container with same name
+    * def resourceUrl = resource.getUrl()
+    Given url resourceUrl
+    And configure headers = clients.alice.getAuthHeaders('PUT', resourceUrl)
+    And request "Hello"
+    When method PUT
+    Then assert responseStatus >= 200 && responseStatus < 300
+
+    * def childContainerUrl = testContainer.getUrl() + 'foo/'
+    Given url childContainerUrl
+    And configure headers = clients.alice.getAuthHeaders('GET', childContainerUrl)
+    When method GET
+    Then match [301, 404, 410] contains responseStatus
+
+    * def childContainerUrl = testContainer.getUrl() + 'foo/'
+    Given url childContainerUrl
+    And configure headers = clients.alice.getAuthHeaders('PUT', childContainerUrl)
+    When method PUT
+     # See https://www.rfc-editor.org/rfc/rfc7231.html#page-27 for why 409 or 415
+    Then match [409, 415] contains responseStatus
+
+
+
+
+# TODO: Evil test to check various suffices.
+
+
+
+
+    

--- a/protocol/writing-resource/slash-semantics-exclude.feature
+++ b/protocol/writing-resource/slash-semantics-exclude.feature
@@ -1,37 +1,39 @@
+@parallel=false
 Feature: With and without trailing slash cannot co-exist
 
   Background: Set up clients and paths
     * def testContainer = createTestContainer()
-    * def resource = testContainer.generateChildResource('/foo')
+    * configure followRedirects = false
 
   Scenario: PUT container, then try resource with same name
     * def childContainerUrl = testContainer.getUrl() + 'foo/'
     Given url childContainerUrl
     And configure headers = clients.alice.getAuthHeaders('PUT', childContainerUrl)
+    And header Content-Type = 'text/turtle'
     When method PUT
     Then assert responseStatus >= 200 && responseStatus < 300
 
-    * def resourceUrl = resource.getUrl()
+    * def resourceUrl = testContainer.getUrl() + 'foo'
     Given url resourceUrl
     And configure headers = clients.alice.getAuthHeaders('GET', resourceUrl)
     When method GET
+    * print response
     Then match [301, 404, 410] contains responseStatus
 
-    * def resourceUrl = resource.getUrl()
     Given url resourceUrl
     And configure headers = clients.alice.getAuthHeaders('PUT', resourceUrl)
+    And header Content-Type = 'text/plain'
     And request "Hello"
     When method PUT
      # See https://www.rfc-editor.org/rfc/rfc7231.html#page-27 for why 409 or 415
     Then match [409, 415] contains responseStatus
 
 
-    
-    
   Scenario: PUT resource, then try container with same name
-    * def resourceUrl = resource.getUrl()
+    * def resourceUrl = testContainer.getUrl() + 'foo'
     Given url resourceUrl
     And configure headers = clients.alice.getAuthHeaders('PUT', resourceUrl)
+    And header Content-Type = 'text/plain'
     And request "Hello"
     When method PUT
     Then assert responseStatus >= 200 && responseStatus < 300
@@ -45,16 +47,14 @@ Feature: With and without trailing slash cannot co-exist
     * def childContainerUrl = testContainer.getUrl() + 'foo/'
     Given url childContainerUrl
     And configure headers = clients.alice.getAuthHeaders('PUT', childContainerUrl)
+    And header Content-Type = 'text/turtle'
     When method PUT
      # See https://www.rfc-editor.org/rfc/rfc7231.html#page-27 for why 409 or 415
     Then match [409, 415] contains responseStatus
-
-
-
 
 # TODO: Evil test to check various suffices.
 
 
 
 
-    
+


### PR DESCRIPTION
This is a first attempt at testing that a server cannot have both a container and a resource that differs only by trailing `/`.

I struggle to understand which response belongs to what request, so I'm confident the tests are correct yet. 
 
```
2021-09-08 00:19:20,676 DEBUG [com.int.karate] (pool-2-thread-1) request:
1 > PUT https://pod.inrupt.com/solid-test-suite-alice/shared-test/6ae92b44-5671-44d1-8b06-4f63aef47e07/ad2f6827-50c3-4686-a901-3568bc6121fc/foo/
1 > Authorization: DPoP ***ftNPfA
1 > User-Agent: Solid-Conformance-Test-Suite
1 > DPoP: ***BXmSWw
1 > Host: pod.inrupt.com
1 > Connection: Keep-Alive
1 > Accept-Encoding: gzip,deflate


2021-09-08 00:19:20,676 DEBUG [com.int.karate] (pool-2-thread-2) request:
1 > PUT https://pod.inrupt.com/solid-test-suite-alice/shared-test/6ae92b44-5671-44d1-8b06-4f63aef47e07/a019df09-eb35-4134-a1a9-b0f4e4933182/8f0e2786-fb7c-4303-b119-5b306ea8da58/foo
1 > Authorization: DPoP ***ftNPfA
1 > User-Agent: Solid-Conformance-Test-Suite
1 > DPoP: ***bmJCgg
1 > Content-Type: text/plain; charset=UTF-8
1 > Content-Length: 5
1 > Host: pod.inrupt.com
1 > Connection: Keep-Alive
1 > Accept-Encoding: gzip,deflate
Hello

2021-09-08 00:19:20,803 DEBUG [com.int.karate] (pool-2-thread-1) response time in milliseconds: 125
1 < 400
1 < Date: Wed, 08 Sep 2021 00:19:20 GMT
1 < Content-Length: 0
1 < Connection: keep-alive
1 < Link: <https://inrupt.com/ns/ess#MissingContentTypeHeader>; rel="http://www.w3.org/ns/ldp#constrainedBy"
1 < Strict-Transport-Security: max-age=15724800; includeSubDomains

2021-09-08 00:19:20,807 ERROR [com.int.karate] (pool-2-thread-1) ../data/protocol/writing-resource/slash-semantics-exclude.feature:12
Then assert responseStatus >= 200 && responseStatus < 300
did not evaluate to 'true': responseStatus >= 200 && responseStatus < 300
../data/protocol/writing-resource/slash-semantics-exclude.feature:12
2021-09-08 00:19:20,832 DEBUG [com.int.karate] (pool-2-thread-2) response time in milliseconds: 155
1 < 201
1 < Date: Wed, 08 Sep 2021 00:19:20 GMT
1 < Content-Length: 0
1 < Connection: keep-alive
1 < Content-Location: https://pod.inrupt.com/solid-test-suite-alice/shared-test/6ae92b44-5671-44d1-8b06-4f63aef47e07/a019df09-eb35-4134-a1a9-b0f4e4933182/8f0e2786-fb7c-4303-b119-5b306ea8da58/foo
1 < Link: <http://www.w3.org/ns/ldp#Resource>; rel="type"
1 < Link: <https://pod.inrupt.com/solid-test-suite-alice/shared-test/6ae92b44-5671-44d1-8b06-4f63aef47e07/a019df09-eb35-4134-a1a9-b0f4e4933182/8f0e2786-fb7c-4303-b119-5b306ea8da58/foo?ext=description>; rel="describedby"
1 < Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel="type"
1 < Link: </solid-test-suite-alice/shared-test/6ae92b44-5671-44d1-8b06-4f63aef47e07/a019df09-eb35-4134-a1a9-b0f4e4933182/8f0e2786-fb7c-4303-b119-5b306ea8da58/foo?ext=shex>; rel="http://www.w3.org/ns/shex#Schema"
1 < Link: </powerswitch/solid-test-suite-alice>; rel="https://inrupt.com/ns/ess#hasPowerSwitch"
1 < Link: </solid-test-suite-alice/shared-test/6ae92b44-5671-44d1-8b06-4f63aef47e07/a019df09-eb35-4134-a1a9-b0f4e4933182/8f0e2786-fb7c-4303-b119-5b306ea8da58/foo?ext=acr>; rel="http://www.w3.org/ns/solid/acp#accessControl"
1 < Link: <http://www.w3.org/ns/solid/acp#Read>; rel="http://www.w3.org/ns/solid/acp#allow"
1 < Link: <http://www.w3.org/ns/solid/acp#Write>; rel="http://www.w3.org/ns/solid/acp#allow"
1 < Strict-Transport-Security: max-age=15724800; includeSubDomains

2021-09-08 00:19:20,836 DEBUG [com.int.karate] (pool-2-thread-2) request:
2 > GET https://pod.inrupt.com/solid-test-suite-alice/shared-test/6ae92b44-5671-44d1-8b06-4f63aef47e07/a019df09-eb35-4134-a1a9-b0f4e4933182/foo/
2 > Authorization: DPoP ***ftNPfA
2 > User-Agent: Solid-Conformance-Test-Suite
2 > DPoP: ***QA9zEA
2 > Host: pod.inrupt.com
2 > Connection: Keep-Alive
2 > Accept-Encoding: gzip,deflate


2021-09-08 00:19:20,983 DEBUG [com.int.karate] (pool-2-thread-2) response time in milliseconds: 123
2 < 404
2 < Date: Wed, 08 Sep 2021 00:19:20 GMT
2 < Content-Type: application/json
2 < Content-Length: 88
2 < Connection: keep-alive
2 < Link: </powerswitch/solid-test-suite-alice>; rel="https://inrupt.com/ns/ess#hasPowerSwitch"
2 < Link: </solid-test-suite-alice>; rel="http://www.w3.org/ns/pim/space#storage"
2 < Link: </solid-test-suite-alice/shared-test/6ae92b44-5671-44d1-8b06-4f63aef47e07/a019df09-eb35-4134-a1a9-b0f4e4933182/foo/?ext=acr>; rel="http://www.w3.org/ns/solid/acp#accessControl"
2 < Link: <http://www.w3.org/ns/solid/acp#Read>; rel="http://www.w3.org/ns/solid/acp#allow"
2 < Link: <http://www.w3.org/ns/solid/acp#Write>; rel="http://www.w3.org/ns/solid/acp#allow"
2 < Strict-Transport-Security: max-age=15724800; includeSubDomains
{"error":{"code":"404","message":"Not Found"}}
2021-09-08 00:19:20,991 DEBUG [com.int.karate] (pool-2-thread-2) over-writing existing variable 'childContainerUrl' with new value: testContainer.getUrl() + 'foo/'
2021-09-08 00:19:20,994 DEBUG [com.int.karate] (pool-2-thread-2) request:
3 > PUT https://pod.inrupt.com/solid-test-suite-alice/shared-test/6ae92b44-5671-44d1-8b06-4f63aef47e07/a019df09-eb35-4134-a1a9-b0f4e4933182/foo/
3 > Authorization: DPoP ***ftNPfA
3 > User-Agent: Solid-Conformance-Test-Suite
3 > DPoP: ***De_uig
3 > Host: pod.inrupt.com
3 > Connection: Keep-Alive
3 > Accept-Encoding: gzip,deflate


2021-09-08 00:19:21,089 DEBUG [com.int.karate] (pool-2-thread-2) response time in milliseconds: 95
3 < 400
3 < Date: Wed, 08 Sep 2021 00:19:21 GMT
3 < Content-Length: 0
3 < Connection: keep-alive
3 < Link: <https://inrupt.com/ns/ess#MissingContentTypeHeader>; rel="http://www.w3.org/ns/ldp#constrainedBy"
3 < Strict-Transport-Security: max-age=15724800; includeSubDomains

---------------------------------------------------------
feature: ../data/protocol/writing-resource/slash-semantics-exclude.feature
scenarios:  2 | passed:  1 | failed:  1 | time: 0.7057
---------------------------------------------------------

2021-09-08 00:19:21,453 INFO  [com.int.kar.Suite] (pool-3-thread-1) <<fail>> feature 1 of 1 (0 remaining) ../data/protocol/writing-resource/slash-semantics-exclude.feature
Karate version: 1.0.1
======================================================
elapsed:   2.18 | threads:    8 | thread time: 0.71 
features:     1 | skipped:    0 | efficiency: 0.04
scenarios:    2 | passed:     1 | failed: 1
======================================================
```