### PR TITLE
A simple Authentication header test

### DIFF
--- a/protocol/authentication/header.feature
+++ b/protocol/authentication/header.feature
@@ -1,0 +1,12 @@
+Feature: Test that unauthenticated users get the correct response
+
+  Background: Setup
+    * def testContainer = createTestContainerImmediate()
+    * def requestUri = testContainer.getUrl()
+
+  Scenario: Unauthenticated user gets an appropriate response
+    Given url requestUri
+    And configure headers = clients.bob.getAuthHeaders('GET', requestUri)
+    When method GET
+    Then status 401
+    And match header WWW-Authenticate != null

--- a/protocol/authentication/header.feature
+++ b/protocol/authentication/header.feature
@@ -23,3 +23,25 @@ Feature: Test that unauthenticated users get the correct response
     When method PUT
     Then status 401
     And match header WWW-Authenticate != null
+
+  Scenario: Unauthenticated user gets an appropriate response on POST
+    Given url requestUri
+    And header Content-Type = 'text/turtle'
+    And request "<> a <#Something> ."
+    When method POST
+    Then status 401
+    And match header WWW-Authenticate != null
+
+  Scenario: Unauthenticated user gets an appropriate response on PATCH
+    Given url requestUri
+    And header Content-Type = 'application/sparql-query'
+    And request "INSERT DATA { <> a <#Something> .}"
+    When method PATCH
+    Then status 401
+    And match header WWW-Authenticate != null
+
+  Scenario: Unauthenticated user gets an appropriate response on DELETE
+    Given url requestUri
+    When method DELETE
+    Then status 401
+    And match header WWW-Authenticate != null

--- a/protocol/authentication/header.feature
+++ b/protocol/authentication/header.feature
@@ -6,7 +6,6 @@ Feature: Test that unauthenticated users get the correct response
 
   Scenario: Unauthenticated user gets an appropriate response
     Given url requestUri
-    And configure headers = clients.bob.getAuthHeaders('GET', requestUri)
     When method GET
     Then status 401
     And match header WWW-Authenticate != null

--- a/protocol/authentication/header.feature
+++ b/protocol/authentication/header.feature
@@ -4,8 +4,22 @@ Feature: Test that unauthenticated users get the correct response
     * def testContainer = createTestContainerImmediate()
     * def requestUri = testContainer.getUrl()
 
-  Scenario: Unauthenticated user gets an appropriate response
+  Scenario: Unauthenticated user gets an appropriate response on GET
     Given url requestUri
     When method GET
+    Then status 401
+    And match header WWW-Authenticate != null
+
+  Scenario: Unauthenticated user gets an appropriate response on HEAD
+    Given url requestUri
+    When method HEAD
+    Then status 401
+    And match header WWW-Authenticate != null
+
+  Scenario: Unauthenticated user gets an appropriate response on PUT
+    Given url requestUri
+    When method PUT
+    And header Content-Type = 'text/turtle'
+    And request "<> a <#Something> ."
     Then status 401
     And match header WWW-Authenticate != null

--- a/protocol/authentication/header.feature
+++ b/protocol/authentication/header.feature
@@ -18,8 +18,8 @@ Feature: Test that unauthenticated users get the correct response
 
   Scenario: Unauthenticated user gets an appropriate response on PUT
     Given url requestUri
-    When method PUT
     And header Content-Type = 'text/turtle'
     And request "<> a <#Something> ."
+    When method PUT
     Then status 401
     And match header WWW-Authenticate != null

--- a/protocol/solid-protocol-spec.ttl
+++ b/protocol/solid-protocol-spec.ttl
@@ -9,50 +9,56 @@
 @prefix spec: <http://www.w3.org/ns/spec#> .
 
 <https://solidproject.org/TR/protocol>
-  a spec:Specification ;
-    spec:requirement <https://solidproject.org/TR/protocol#sr-http-content-type>,
-                   <https://solidproject.org/TR/protocol#resource-representations>,
-                   <https://solidproject.org/TR/protocol#writing-resources>,
-                   <https://solidproject.org/TR/protocol#web-access-control>
+    a spec:Specification ;
+    spec:requirement
+        <https://solidproject.org/TR/protocol#sr-http-content-type>,
+        <https://solidproject.org/TR/protocol#resource-representations>,
+        <https://solidproject.org/TR/protocol#writing-resources>,
+        <https://solidproject.org/TR/protocol#web-access-control>,
+        <https://solidproject.org/TR/protocol#sr-http-authen-spec>
 .
 
 <https://solidproject.org/TR/protocol#sr-http-content-type>
-  a spec:NormativeRequirement ;
-  spec:requirementSubject spec:Server ;
-  spec:requirementLevel spec:MUST ;
-  schema:name "Content-Type on Writes" ;
-  schema:description "Full text of the specification section" ;
-  spec:statement "A Solid server MUST reject PUT, POST and PATCH requests without the Content-Type header with a status code of 400."
+    a spec:NormativeRequirement ;
+    spec:requirementSubject spec:Server ;
+    spec:requirementLevel spec:MUST ;
+    schema:name "Content-Type on Writes" ;
+    schema:description "Full text of the specification section" ;
+    spec:statement
+        "A Solid server MUST reject PUT, POST and PATCH requests without the Content-Type header with a status code of 400."
 .
 
 <https://solidproject.org/TR/protocol#sr-http-authen-spec>
-  a spec:NormativeRequirement ;
-  spec:requirementSubject spec:Server ;
-  spec:requirementLevel spec:MUST ;
-  schema:name "RFC 7235" ;
-  schema:description "Full text of the specification section" ;
-  spec:statement "A data pod MUST implement the server part of HTTP/1.1 Authentication."
+    a spec:NormativeRequirement ;
+    spec:requirementSubject spec:Server ;
+    spec:requirementLevel spec:MUST ;
+    schema:name "RFC 7235" ;
+    schema:description "Full text of the specification section" ;
+    spec:statement "A data pod MUST implement the server part of HTTP/1.1 Authentication."
 .
 
 <https://solidproject.org/TR/protocol#resource-representations>
-  a spec:NormativeRequirement ;
-  schema:name "Resource Representations" ;
-  schema:description "Full text of the specification section" ;
-  spec:statement "the server MUST accept GET requests on this resource when the value of the Accept header requests a representation in text/turtle or application/ld+json"
+    a spec:NormativeRequirement ;
+    schema:name "Resource Representations" ;
+    schema:description "Full text of the specification section" ;
+    spec:statement
+        "the server MUST accept GET requests on this resource when the value of the Accept header requests a representation in text/turtle or application/ld+json"
 .
 
 <https://solidproject.org/TR/protocol#writing-resources>
-  a spec:NormativeRequirement ;
-  spec:requirementSubject spec:Server ;
-  spec:requirementLevel spec:MUST ;
-  spec:statement "Servers MUST create intermediate containers and include corresponding containment triples in container representations derived from the URI path component of PUT and PATCH requests"
+    a spec:NormativeRequirement ;
+    spec:requirementSubject spec:Server ;
+    spec:requirementLevel spec:MUST ;
+    spec:statement
+        "Servers MUST create intermediate containers and include corresponding containment triples in container representations derived from the URI path component of PUT and PATCH requests"
 .
 
 <https://solidproject.org/TR/protocol#web-access-control>
-  a spec:NormativeRequirement ;
-  spec:requirementSubject spec:Server ;
-  spec:requirementLevel spec:MUST ;
-  spec:statement "Servers exposing client’s access privileges on a resource URL MUST advertise by including the WAC-Allow HTTP header in the response of HTTP HEAD and GET requests"
+    a spec:NormativeRequirement ;
+    spec:requirementSubject spec:Server ;
+    spec:requirementLevel spec:MUST ;
+    spec:statement
+        "Servers exposing client’s access privileges on a resource URL MUST advertise by including the WAC-Allow HTTP header in the response of HTTP HEAD and GET requests"
 .
 
 #<https://solidproject.org/TR/protocol#test-server-header-put-content-type>

--- a/protocol/solid-protocol-spec.ttl
+++ b/protocol/solid-protocol-spec.ttl
@@ -25,6 +25,15 @@
   spec:statement "A Solid server MUST reject PUT, POST and PATCH requests without the Content-Type header with a status code of 400."
 .
 
+<https://solidproject.org/TR/protocol#sr-http-authen-spec>
+  a spec:NormativeRequirement ;
+  spec:requirementSubject spec:Server ;
+  spec:requirementLevel spec:MUST ;
+  schema:name "RFC 7235" ;
+  schema:description "Full text of the specification section" ;
+  spec:statement "A data pod MUST implement the server part of HTTP/1.1 Authentication."
+.
+
 <https://solidproject.org/TR/protocol#resource-representations>
   a spec:NormativeRequirement ;
   schema:name "Resource Representations" ;

--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -14,6 +14,14 @@ manifest:content-type-reject
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/writing-resource/content-type-reject.feature> .
 
+manifest:authentication-header
+  a td:TestCase ;
+  spec:requirementReference <https://solidproject.org/TR/protocol#sr-http-authen-spec>,
+    <https://solidproject.org/TR/protocol#sr-http-unauthenticated> ;
+  td:reviewStatus td:unreviewed ;
+  spec:testScript
+    <https://github.com/solid/specification-tests/protocol/authentication/header.feature> .
+
 manifest:content-negotiation-jsonld
   a td:TestCase ;
   spec:requirementReference <https://solidproject.org/TR/protocol#resource-representations> ;


### PR DESCRIPTION
The protocol does not need much with respect to compliance from RFC 7235, just make sure it gets a `401` and a header for unauthenticated agents.