### PR TITLE
Use a prefix for the protocol

### DIFF
--- a/protocol/converted.ttl
+++ b/protocol/converted.ttl
@@ -4,12 +4,13 @@ prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix dcterms: <http://purl.org/dc/terms/>
 prefix td: <http://www.w3.org/2006/03/test-description#>
 prefix spec: <http://www.w3.org/ns/spec#>
+prefix protocol: <https://solidproject.org/TR/protocol#>
 
 prefix manifest: <#>
 
 manifest:converted-test1
   a td:TestCase ;
-#  spec:requirementReference <https://solidproject.org/TR/protocol#resource-representations> ;
+#  spec:requirementReference protocol:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/converted/test_1-1.feature> ,
@@ -20,14 +21,14 @@ manifest:converted-test1
 
 manifest:converted-test2
   a td:TestCase ;
-#  spec:requirementReference <https://solidproject.org/TR/protocol#resource-representations> ;
+#  spec:requirementReference protocol:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/converted/test_2-1.feature> .
 
 manifest:converted-test3
   a td:TestCase ;
-#  spec:requirementReference <https://solidproject.org/TR/protocol#resource-representations> ;
+#  spec:requirementReference protocol:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/converted/test_3-1.feature> ,
@@ -37,7 +38,7 @@ manifest:converted-test3
 
 manifest:converted-test4
   a td:TestCase ;
-#  spec:requirementReference <https://solidproject.org/TR/protocol#resource-representations> ;
+#  spec:requirementReference protocol:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/converted/test_4-1.feature> ,
@@ -48,7 +49,7 @@ manifest:converted-test4
 
 manifest:converted-test5
   a td:TestCase ;
-#  spec:requirementReference <https://solidproject.org/TR/protocol#resource-representations> ;
+#  spec:requirementReference protocol:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/converted/test_5-1.feature> ,

--- a/protocol/converted.ttl
+++ b/protocol/converted.ttl
@@ -4,13 +4,13 @@ prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix dcterms: <http://purl.org/dc/terms/>
 prefix td: <http://www.w3.org/2006/03/test-description#>
 prefix spec: <http://www.w3.org/ns/spec#>
-prefix protocol: <https://solidproject.org/TR/protocol#>
+prefix sopr: <https://solidproject.org/TR/protocol#>
 
 prefix manifest: <#>
 
 manifest:converted-test1
   a td:TestCase ;
-#  spec:requirementReference protocol:resource-representations ;
+#  spec:requirementReference sopr:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/converted/test_1-1.feature> ,
@@ -21,14 +21,14 @@ manifest:converted-test1
 
 manifest:converted-test2
   a td:TestCase ;
-#  spec:requirementReference protocol:resource-representations ;
+#  spec:requirementReference sopr:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/converted/test_2-1.feature> .
 
 manifest:converted-test3
   a td:TestCase ;
-#  spec:requirementReference protocol:resource-representations ;
+#  spec:requirementReference sopr:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/converted/test_3-1.feature> ,
@@ -38,7 +38,7 @@ manifest:converted-test3
 
 manifest:converted-test4
   a td:TestCase ;
-#  spec:requirementReference protocol:resource-representations ;
+#  spec:requirementReference sopr:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/converted/test_4-1.feature> ,
@@ -49,7 +49,7 @@ manifest:converted-test4
 
 manifest:converted-test5
   a td:TestCase ;
-#  spec:requirementReference protocol:resource-representations ;
+#  spec:requirementReference sopr:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/converted/test_5-1.feature> ,

--- a/protocol/solid-protocol-spec.ttl
+++ b/protocol/solid-protocol-spec.ttl
@@ -7,19 +7,19 @@
 @prefix httpm: <http://www.w3.org/2011/http-methods#> .
 @prefix httph: <http://www.w3.org/2011/http-headers#> .
 @prefix spec: <http://www.w3.org/ns/spec#> .
-@prefix protocol: <https://solidproject.org/TR/protocol#> .
+@prefix sopr: <https://solidproject.org/TR/protocol#> .
 
 <https://solidproject.org/TR/protocol>
   a spec:Specification ;
-    spec:requirement protocol:sr-http-content-type,
-                   protocol:resource-representations,
-                   protocol:writing-resources,
-                   protocol:web-access-control,
-                   protocol:sr-uri-trailing-slash-distinct,
-                   protocol:sr-http-authen-spec
+    spec:requirement sopr:sr-http-content-type,
+                   sopr:resource-representations,
+                   sopr:writing-resources,
+                   sopr:web-access-control,
+                   sopr:sr-uri-trailing-slash-distinct,
+                   sopr:sr-http-authen-spec
 .
 
-protocol:sr-http-content-type
+sopr:sr-http-content-type
     a spec:NormativeRequirement ;
     spec:requirementSubject spec:Server ;
     spec:requirementLevel spec:MUST ;
@@ -29,7 +29,7 @@ protocol:sr-http-content-type
         "A Solid server MUST reject PUT, POST and PATCH requests without the Content-Type header with a status code of 400."
 .
 
-protocol:sr-http-authen-spec
+sopr:sr-http-authen-spec
     a spec:NormativeRequirement ;
     spec:requirementSubject spec:Server ;
     spec:requirementLevel spec:MUST ;
@@ -38,7 +38,7 @@ protocol:sr-http-authen-spec
     spec:statement "A data pod MUST implement the server part of HTTP/1.1 Authentication."
 .
 
-protocol:sr-uri-trailing-slash-distinct
+sopr:sr-uri-trailing-slash-distinct
   a spec:NormativeRequirement ;
   spec:requirementSubject spec:Server ;
   spec:requirementLevel spec:MUST ;
@@ -48,7 +48,7 @@ protocol:sr-uri-trailing-slash-distinct
 .
 
 
-protocol:resource-representations
+sopr:resource-representations
     a spec:NormativeRequirement ;
     schema:name "Resource Representations" ;
     schema:description "Full text of the specification section" ;
@@ -56,7 +56,7 @@ protocol:resource-representations
         "the server MUST accept GET requests on this resource when the value of the Accept header requests a representation in text/turtle or application/ld+json"
 .
 
-protocol:writing-resources
+sopr:writing-resources
     a spec:NormativeRequirement ;
     spec:requirementSubject spec:Server ;
     spec:requirementLevel spec:MUST ;
@@ -64,7 +64,7 @@ protocol:writing-resources
         "Servers MUST create intermediate containers and include corresponding containment triples in container representations derived from the URI path component of PUT and PATCH requests"
 .
 
-protocol:web-access-control
+sopr:web-access-control
     a spec:NormativeRequirement ;
     spec:requirementSubject spec:Server ;
     spec:requirementLevel spec:MUST ;
@@ -72,7 +72,7 @@ protocol:web-access-control
         "Servers exposing client’s access privileges on a resource URL MUST advertise by including the WAC-Allow HTTP header in the response of HTTP HEAD and GET requests"
 .
 
-#protocol:test-server-header-put-content-type
+#sopr:test-server-header-put-content-type
 #  a spec:NormativeRequirement ;
 #  spec:requirementSubject spec:Server ;
 #  spec:requirementLevel spec:MUST ;

--- a/protocol/solid-protocol-spec.ttl
+++ b/protocol/solid-protocol-spec.ttl
@@ -7,18 +7,19 @@
 @prefix httpm: <http://www.w3.org/2011/http-methods#> .
 @prefix httph: <http://www.w3.org/2011/http-headers#> .
 @prefix spec: <http://www.w3.org/ns/spec#> .
+@prefix protocol: <https://solidproject.org/TR/protocol#> .
 
 <https://solidproject.org/TR/protocol>
   a spec:Specification ;
-    spec:requirement <https://solidproject.org/TR/protocol#sr-http-content-type>,
-                   <https://solidproject.org/TR/protocol#resource-representations>,
-                   <https://solidproject.org/TR/protocol#writing-resources>,
-                   <https://solidproject.org/TR/protocol#web-access-control>,
-                   <https://solidproject.org/TR/protocol#sr-uri-trailing-slash-distinct>,
-                   <https://solidproject.org/TR/protocol#sr-http-authen-spec>
+    spec:requirement protocol:sr-http-content-type,
+                   protocol:resource-representations,
+                   protocol:writing-resources,
+                   protocol:web-access-control,
+                   protocol:sr-uri-trailing-slash-distinct,
+                   protocol:sr-http-authen-spec
 .
 
-<https://solidproject.org/TR/protocol#sr-http-content-type>
+protocol:sr-http-content-type
     a spec:NormativeRequirement ;
     spec:requirementSubject spec:Server ;
     spec:requirementLevel spec:MUST ;
@@ -28,7 +29,7 @@
         "A Solid server MUST reject PUT, POST and PATCH requests without the Content-Type header with a status code of 400."
 .
 
-<https://solidproject.org/TR/protocol#sr-http-authen-spec>
+protocol:sr-http-authen-spec
     a spec:NormativeRequirement ;
     spec:requirementSubject spec:Server ;
     spec:requirementLevel spec:MUST ;
@@ -37,7 +38,7 @@
     spec:statement "A data pod MUST implement the server part of HTTP/1.1 Authentication."
 .
 
-<https://solidproject.org/TR/protocol#sr-uri-trailing-slash-distinct>
+protocol:sr-uri-trailing-slash-distinct
   a spec:NormativeRequirement ;
   spec:requirementSubject spec:Server ;
   spec:requirementLevel spec:MUST ;
@@ -47,7 +48,7 @@
 .
 
 
-<https://solidproject.org/TR/protocol#resource-representations>
+protocol:resource-representations
     a spec:NormativeRequirement ;
     schema:name "Resource Representations" ;
     schema:description "Full text of the specification section" ;
@@ -55,7 +56,7 @@
         "the server MUST accept GET requests on this resource when the value of the Accept header requests a representation in text/turtle or application/ld+json"
 .
 
-<https://solidproject.org/TR/protocol#writing-resources>
+protocol:writing-resources
     a spec:NormativeRequirement ;
     spec:requirementSubject spec:Server ;
     spec:requirementLevel spec:MUST ;
@@ -63,7 +64,7 @@
         "Servers MUST create intermediate containers and include corresponding containment triples in container representations derived from the URI path component of PUT and PATCH requests"
 .
 
-<https://solidproject.org/TR/protocol#web-access-control>
+protocol:web-access-control
     a spec:NormativeRequirement ;
     spec:requirementSubject spec:Server ;
     spec:requirementLevel spec:MUST ;
@@ -71,7 +72,7 @@
         "Servers exposing client’s access privileges on a resource URL MUST advertise by including the WAC-Allow HTTP header in the response of HTTP HEAD and GET requests"
 .
 
-#<https://solidproject.org/TR/protocol#test-server-header-put-content-type>
+#protocol:test-server-header-put-content-type
 #  a spec:NormativeRequirement ;
 #  spec:requirementSubject spec:Server ;
 #  spec:requirementLevel spec:MUST ;

--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -4,43 +4,43 @@ prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix dcterms: <http://purl.org/dc/terms/>
 prefix td: <http://www.w3.org/2006/03/test-description#>
 prefix spec: <http://www.w3.org/ns/spec#>
-    prefix protocol: <https://solidproject.org/TR/protocol#>
+    prefix sopr: <https://solidproject.org/TR/protocol#>
 
 prefix manifest: <#>
 
 manifest:content-type-reject
   a td:TestCase ;
-  spec:requirementReference protocol:sr-http-content-type ;
+  spec:requirementReference sopr:sr-http-content-type ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/writing-resource/content-type-reject.feature> .
 
 manifest:slash-semantics-exclude
   a td:TestCase ;
-    spec:requirementReference protocol:sr-uri-trailing-slash-distinct ,
-    protocol:sr-uri-redirect-differing ;
+    spec:requirementReference sopr:sr-uri-trailing-slash-distinct ,
+    sopr:sr-uri-redirect-differing ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/writing-resource/slash-semantics-exclude.feature> .
 
 manifest:authentication-header
   a td:TestCase ;
-  spec:requirementReference protocol:sr-http-authen-spec,
-    protocol:sr-http-unauthenticated ;
+  spec:requirementReference sopr:sr-http-authen-spec,
+    sopr:sr-http-unauthenticated ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/authentication/header.feature> .
 
 manifest:content-negotiation-jsonld
   a td:TestCase ;
-  spec:requirementReference protocol:resource-representations ;
+  spec:requirementReference sopr:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/content-negotiation/content-negotiation-jsonld.feature> .
 
 manifest:content-negotiation-turtle
   a td:TestCase ;
-  spec:requirementReference protocol:resource-representations ;
+  spec:requirementReference sopr:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/content-negotiation/content-negotiation-turtle.feature> .
@@ -51,14 +51,14 @@ manifest:content-negotiation-rdfa
 
 manifest:writing-resource-containment
   a td:TestCase ;
-  spec:requirementReference protocol:writing-resources ;
+  spec:requirementReference sopr:writing-resources ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/writing-resource/containment.feature> .
 
 manifest:wac-allow-access-Bob-W-public-RA
   a td:TestCase ;
-  spec:requirementReference protocol:web-access-control ;
+  spec:requirementReference sopr:web-access-control ;
   td:reviewStatus td:unreviewed ;
   td:preCondition "authentication", "acl", "wac-allow" ;
   spec:testScript
@@ -66,7 +66,7 @@ manifest:wac-allow-access-Bob-W-public-RA
 
 manifest:wac-allow-default-Bob-W-public-RA
   a td:TestCase ;
-  spec:requirementReference protocol:web-access-control ;
+  spec:requirementReference sopr:web-access-control ;
   td:reviewStatus td:unreviewed ;
   td:preCondition "authentication", "acl", "wac-allow" ;
   spec:testScript
@@ -74,7 +74,7 @@ manifest:wac-allow-default-Bob-W-public-RA
 
 manifest:wac-allow-access-public-R
   a td:TestCase ;
-  spec:requirementReference protocol:web-access-control ;
+  spec:requirementReference sopr:web-access-control ;
   td:reviewStatus td:unreviewed ;
   td:preCondition "authentication", "acl", "wac-allow" ;
   spec:testScript

--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -4,42 +4,43 @@ prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix dcterms: <http://purl.org/dc/terms/>
 prefix td: <http://www.w3.org/2006/03/test-description#>
 prefix spec: <http://www.w3.org/ns/spec#>
+    prefix protocol: <https://solidproject.org/TR/protocol#>
 
 prefix manifest: <#>
 
 manifest:content-type-reject
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#sr-http-content-type> ;
+  spec:requirementReference protocol:sr-http-content-type ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/writing-resource/content-type-reject.feature> .
 
 manifest:slash-semantics-exclude
   a td:TestCase ;
-    spec:requirementReference <https://solidproject.org/TR/protocol#sr-uri-trailing-slash-distinct> ,
-    <https://solidproject.org/TR/protocol#sr-uri-redirect-differing> ;
+    spec:requirementReference protocol:sr-uri-trailing-slash-distinct ,
+    protocol:sr-uri-redirect-differing ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/writing-resource/slash-semantics-exclude.feature> .
 
 manifest:authentication-header
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#sr-http-authen-spec>,
-    <https://solidproject.org/TR/protocol#sr-http-unauthenticated> ;
+  spec:requirementReference protocol:sr-http-authen-spec,
+    protocol:sr-http-unauthenticated ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/authentication/header.feature> .
 
 manifest:content-negotiation-jsonld
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#resource-representations> ;
+  spec:requirementReference protocol:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/content-negotiation/content-negotiation-jsonld.feature> .
 
 manifest:content-negotiation-turtle
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#resource-representations> ;
+  spec:requirementReference protocol:resource-representations ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/content-negotiation/content-negotiation-turtle.feature> .
@@ -50,14 +51,14 @@ manifest:content-negotiation-rdfa
 
 manifest:writing-resource-containment
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#writing-resources> ;
+  spec:requirementReference protocol:writing-resources ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/writing-resource/containment.feature> .
 
 manifest:wac-allow-access-Bob-W-public-RA
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#web-access-control> ;
+  spec:requirementReference protocol:web-access-control ;
   td:reviewStatus td:unreviewed ;
   td:preCondition "authentication", "acl", "wac-allow" ;
   spec:testScript
@@ -65,7 +66,7 @@ manifest:wac-allow-access-Bob-W-public-RA
 
 manifest:wac-allow-default-Bob-W-public-RA
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#web-access-control> ;
+  spec:requirementReference protocol:web-access-control ;
   td:reviewStatus td:unreviewed ;
   td:preCondition "authentication", "acl", "wac-allow" ;
   spec:testScript
@@ -73,7 +74,7 @@ manifest:wac-allow-default-Bob-W-public-RA
 
 manifest:wac-allow-access-public-R
   a td:TestCase ;
-  spec:requirementReference <https://solidproject.org/TR/protocol#web-access-control> ;
+  spec:requirementReference protocol:web-access-control ;
   td:reviewStatus td:unreviewed ;
   td:preCondition "authentication", "acl", "wac-allow" ;
   spec:testScript


### PR DESCRIPTION
I suggest we use a prefix for the protocol document in the manifest (and similar). It'll make it feasible to type.