### PR TITLE
Use application/sparql-update for PATCH requests

### DIFF
--- a/protocol/authentication/header.feature
+++ b/protocol/authentication/header.feature
@@ -34,7 +34,7 @@ Feature: Test that unauthenticated users get the correct response
 
   Scenario: Unauthenticated user gets an appropriate response on PATCH
     Given url requestUri
-    And header Content-Type = 'application/sparql-query'
+    And header Content-Type = 'application/sparql-update'
     And request "INSERT DATA { <> a <#Something> .}"
     When method PATCH
     Then status 401


### PR DESCRIPTION
`application/sparql-query` is used for standard SPARQL queries, SPARQL UPDATE queries use `application/sparql-update`. See https://www.w3.org/TR/sparql11-update/#mediaType