### PR TITLE
Add new server and improve ACL test

### DIFF
--- a/test-subjects.ttl
+++ b/test-subjects.ttl
@@ -18,12 +18,27 @@
     doap:homepage <https://inrupt.com/products/enterprise-solid-server> ;
     doap:description "A production-grade Solid server produced and supported by Inrupt."@en ;
     doap:programming-language "Java"@en ;
-    solid-test:features "authentication", "acl" . # "acp"
+    solid-test:features "authentication", "acl", "acp-legacy" .
 
 <ess#test-subject-release>
     doap:name "ESS 1.1.4";
     doap:revision "1.1.4";
     doap:created "2021-08-06"^^xsd:date .
+
+<ess-next>
+    a earl:Software, earl:TestSubject ;
+    doap:name "Enterprise Solid Server (ACP version)"@en ;
+    doap:release <ess-next#test-subject-release> ;
+    doap:developer <https://inrupt.com/profile/card/#us> ;
+    doap:homepage <https://inrupt.com/products/enterprise-solid-server> ;
+    doap:description "A production-grade Solid server produced and supported by Inrupt."@en ;
+    doap:programming-language "Java"@en ;
+    solid-test:features "authentication", "acl", "acp" .
+
+<ess-next#test-subject-release>
+    doap:name "ESS 1.2";
+    doap:revision "1.2";
+    doap:created "2021-10-05"^^xsd:date .
 
 <ess-wac>
     a earl:Software, earl:TestSubject ;
@@ -33,7 +48,7 @@
     doap:homepage <https://inrupt.com/products/enterprise-solid-server> ;
     doap:description "A production-grade Solid server produced and supported by Inrupt."@en ;
     doap:programming-language "Java"@en ;
-    solid-test:features "authentication", "acl", "wac-allow" . # "wac"
+    solid-test:features "authentication", "acl", "wac-allow", "wac" .
 
 <ess-wac#test-subject-release>
     doap:name "ESS 1.1.4";
@@ -48,7 +63,7 @@
     doap:homepage <https://github.com/solid/community-server> ;
     doap:description "An open and modular implementation of the Solid specifications."@en ;
     doap:programming-language "TypeScript"@en ;
-    solid-test:features "authentication", "acl", "wac-allow" .
+    solid-test:features "authentication", "acl", "wac-allow", "wac" .
 
 <css#test-subject-release>
     doap:name "CSS 1.0.0" ;
@@ -63,7 +78,7 @@
     doap:homepage <https://github.com/solid/node-solid-server> ;
     doap:description "Solid server on top of the file-system in NodeJS."@en ;
     doap:programming-language "JavaScript"@en ;
-    solid-test:features "authentication", "acl", "wac-allow" .
+    solid-test:features "authentication", "acl", "wac-allow", "wac" .
 
 <nss#test-subject-release>
     doap:name "NSS 5.6.6"@en ;
@@ -79,7 +94,7 @@
     doap:description
         "TrinPod™ is an Industrial strength Solid Pod with conceptual computing through Trinity AI Capable of handling a massive amount of data."@en ;
     doap:programming-language "Common Lisp"@en ;
-    solid-test:features "authentication", "acl", "wac-allow" .
+    solid-test:features "authentication", "acl", "wac-allow", "wac" .
 
 <trinpod#test-subject-release>
     doap:name "TrinPod-Server"@en ;

--- a/web-access-control/protected-operation/acl-propagation.feature
+++ b/web-access-control/protected-operation/acl-propagation.feature
@@ -16,7 +16,6 @@ Feature: Inheritable ACL controls child resources
           .setAgentAccess(container.getUrl(), webIds.bob, ['read', 'write'])
           .setInheritableAgentAccess(container.getUrl(), webIds.bob, ['read', 'write'])
           .build();
-        karate.log('ACL:\n' + access.asTurtle());
         container.setAccessDataset(access);
       }
     """
@@ -40,21 +39,16 @@ Feature: Inheritable ACL controls child resources
     And headers clients.bob.getAuthHeaders('PUT', resource2.getUrl())
     And header Content-Type = 'text/plain'
     When method PUT
-    # Only 201 because of https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.4
-    Then status 201
+    Then match [200, 201, 204, 205] contains responseStatus
 
     # Bob can read the new resource
-    * print resource2.getAccessDataset().asTurtle()
     Given url resource2.getUrl()
     And headers clients.bob.getAuthHeaders('GET', resource2.getUrl())
     When method GET
     Then status 200
 
     # Bob can now read the original resource
-    * print resource.getAccessDataset().asTurtle()
     Given url resourceUrl
     And headers clients.bob.getAuthHeaders('GET', resourceUrl)
     When method GET
     Then status 200
-
-


### PR DESCRIPTION
Added ESS1.2 and clarified the wac/acp support of all servers - test-subects.ttl.
In one test case, opened up response codes and remove logging which will be done better in the next test harness release.
