### PR TITLE
Allow 401 or 404

### DIFF
--- a/protocol/authentication/header.feature
+++ b/protocol/authentication/header.feature
@@ -7,13 +7,13 @@ Feature: Test that unauthenticated users get the correct response
   Scenario: Unauthenticated user gets an appropriate response on GET
     Given url requestUri
     When method GET
-    Then match [401, 404] contains responseStatus
+    Then match [401, 403] contains responseStatus
     And match header WWW-Authenticate != null
 
   Scenario: Unauthenticated user gets an appropriate response on HEAD
     Given url requestUri
     When method HEAD
-    Then match [401, 404] contains responseStatus
+    Then match [401, 403] contains responseStatus
     And match header WWW-Authenticate != null
 
   Scenario: Unauthenticated user gets an appropriate response on PUT
@@ -21,7 +21,7 @@ Feature: Test that unauthenticated users get the correct response
     And header Content-Type = 'text/turtle'
     And request "<> a <#Something> ."
     When method PUT
-    Then match [401, 404] contains responseStatus
+    Then match [401, 403] contains responseStatus
     And match header WWW-Authenticate != null
 
   Scenario: Unauthenticated user gets an appropriate response on POST
@@ -29,7 +29,7 @@ Feature: Test that unauthenticated users get the correct response
     And header Content-Type = 'text/turtle'
     And request "<> a <#Something> ."
     When method POST
-    Then match [401, 404] contains responseStatus
+    Then match [401, 403] contains responseStatus
     And match header WWW-Authenticate != null
 
   Scenario: Unauthenticated user gets an appropriate response on PATCH
@@ -37,11 +37,11 @@ Feature: Test that unauthenticated users get the correct response
     And header Content-Type = 'application/sparql-update'
     And request "INSERT DATA { <> a <#Something> .}"
     When method PATCH
-    Then match [401, 404] contains responseStatus
+    Then match [401, 403] contains responseStatus
     And match header WWW-Authenticate != null
 
   Scenario: Unauthenticated user gets an appropriate response on DELETE
     Given url requestUri
     When method DELETE
-    Then match [401, 404] contains responseStatus
+    Then match [401, 403] contains responseStatus
     And match header WWW-Authenticate != null


### PR DESCRIPTION
The spec says:
> When a client does not provide valid credentials when requesting a resource that requires it (see WebID), the server MUST send a response with a 401 status code (unless 404 is preferred for security reasons).

Therefore shouldn't the test allow either.