### PR TITLE
Send a blank header instead of replacing the auth headers

### DIFF
--- a/protocol/writing-resource/content-type-reject.feature
+++ b/protocol/writing-resource/content-type-reject.feature
@@ -8,7 +8,7 @@ Feature: Server MUST reject write requests without Content-Type
     * def resourceUrl = resource.getUrl()
     Given url resourceUrl
     And configure headers = clients.alice.getAuthHeaders('PUT', resourceUrl)
-    And configure headers = { 'Content-Type': '' }
+    And header Content-Type = ''
     And request "<> a <#Something> ."
     When method PUT
     Then status 400
@@ -17,16 +17,16 @@ Feature: Server MUST reject write requests without Content-Type
     * def containerUrl = testContainer.getUrl()
     Given url containerUrl
     And configure headers = clients.alice.getAuthHeaders('POST', containerUrl)
-    And configure headers = { 'Content-Type': '' }
+    And header Content-Type = ''
     And request "<> a <#Something> ."
     When method POST
     Then status 400
-    
+
   Scenario: Server rejects PATCH requests without Content-Type
     * def resourceUrl = resource.getUrl()
     Given url resourceUrl
     And configure headers = clients.alice.getAuthHeaders('PATCH', resourceUrl)
-    And configure headers = { 'Content-Type': '' }
+    And header Content-Type = ''
     And request "INSERT DATA { <> a <#Something> . }"
     When method PATCH
     Then status 400


### PR DESCRIPTION
Using `configure headers` twice meant that the second instance overwrote the first and no Auth headers were sent. The tests were passing on some servers because the `Content-Type` header was checked before authorization failing. On other servers auth was checked first. This fix ensures that auth is not an issue.

The test will be improved when we fix Karate to allow no header to be sent.