### PR TITLE
Correct labels on tests

### DIFF
--- a/protocol/converted/test_4-7.feature
+++ b/protocol/converted/test_4-7.feature
@@ -52,7 +52,7 @@ Feature: Check that Bob can read and write to RDF resource when he is authorized
     When method PATCH
     Then match [200, 204, 205] contains responseStatus
 
-  Scenario: Test 7.7 Append resource (POST) allowed
+  Scenario: Test 7.7 Append resource (POST) denied
     Given url requestUri
     And headers clients.bob.getAuthHeaders('POST', requestUri)
     And header Content-Type = 'text/turtle'

--- a/protocol/converted/test_5-3.feature
+++ b/protocol/converted/test_5-3.feature
@@ -44,7 +44,7 @@ Feature: Check that Bob can only append to Non-RDF resource when he is authorize
     When method PATCH
     Then match [400, 403, 405, 415] contains responseStatus
 
-  Scenario: Test 3.6 Append resource (POST) allowed
+  Scenario: Test 3.6 Append resource (POST) denied
     Given url requestUri
     And configure headers = clients.bob.getAuthHeaders('POST', requestUri)
     And header Content-Type = 'text/plain'

--- a/protocol/converted/test_5-5.feature
+++ b/protocol/converted/test_5-5.feature
@@ -44,7 +44,7 @@ Feature: Check that Bob can read and append to Non-RDF resource when he is autho
     When method PATCH
     Then match [400, 403, 405, 415] contains responseStatus
 
-  Scenario: Test 5.6 Append resource (POST) allowed
+  Scenario: Test 5.6 Append resource (POST) denied
     Given url requestUri
     And configure headers = clients.bob.getAuthHeaders('POST', requestUri)
     And header Content-Type = 'text/plain'

--- a/protocol/converted/test_5-7.feature
+++ b/protocol/converted/test_5-7.feature
@@ -44,7 +44,7 @@ Feature: Check that Bob can read and write to Non-RDF resource when he is author
     When method PATCH
     Then status 415
 
-  Scenario: Test 7.6 Append resource (POST) allowed
+  Scenario: Test 7.6 Append resource (POST) denied
     Given url requestUri
     And configure headers = clients.bob.getAuthHeaders('POST', requestUri)
     And header Content-Type = 'text/plain'


### PR DESCRIPTION
Should be pretty self-explanatory, some labels on tests still said "allowed" when the tests were actually testing denial.