### PR TITLE
Testing the NSS semaphore mechanism

### DIFF
--- a/protocol/converted/test_4-7.feature
+++ b/protocol/converted/test_4-7.feature
@@ -59,6 +59,8 @@ Feature: Check that Bob can read and write to RDF resource when he is authorized
     And request 'INSERT DATA { <> a <http://example.org/Foo> . }'
     When method PATCH
     Then match [200, 204, 205] contains responseStatus
+
+    Given url requestUri
     And headers clients.bob.getAuthHeaders('PATCH', requestUri)
     And header Content-Type = 'application/sparql-update'
     And request 'DELETE { ?s a ?o . } INSERT { <> a <http://example.org/Bar> . } WHERE  { ?s a ?o . }'

--- a/protocol/converted/test_4-7.feature
+++ b/protocol/converted/test_4-7.feature
@@ -52,6 +52,19 @@ Feature: Check that Bob can read and write to RDF resource when he is authorized
     When method PATCH
     Then status 409
 
+  Scenario: Write resource (PATCH) and delete allowed
+    Given url requestUri
+    And headers clients.bob.getAuthHeaders('PATCH', requestUri)
+    And header Content-Type = 'application/sparql-update'
+    And request 'INSERT DATA { <> a <http://example.org/Foo> . }'
+    When method PATCH
+    Then match [200, 204, 205] contains responseStatus
+    And headers clients.bob.getAuthHeaders('PATCH', requestUri)
+    And header Content-Type = 'application/sparql-update'
+    And request 'DELETE { ?s a ?o . } INSERT { <> a <http://example.org/Bar> . } WHERE  { ?s a ?o . }'
+    When method PATCH
+    Then match [200, 204, 205] contains responseStatus
+
   Scenario: Test 7.7 Append resource (POST) allowed
     Given url requestUri
     And headers clients.bob.getAuthHeaders('POST', requestUri)

--- a/protocol/converted/test_4-7.feature
+++ b/protocol/converted/test_4-7.feature
@@ -44,13 +44,13 @@ Feature: Check that Bob can read and write to RDF resource when he is authorized
     When method PATCH
     Then match [200, 204, 205] contains responseStatus
 
-  Scenario: Test 7.6 Write resource (PATCH) with delete allowed
+  Scenario: Test 7.6 Write resource on empty resource (PATCH) with delete conflicts
     Given url requestUri
     And headers clients.bob.getAuthHeaders('PATCH', requestUri)
     And header Content-Type = 'application/sparql-update'
     And request 'DELETE { ?s a ?o . } INSERT { <> a <http://example.org/Bar> . } WHERE  { ?s a ?o . }'
     When method PATCH
-    Then match [200, 204, 205] contains responseStatus
+    Then status 409
 
   Scenario: Test 7.7 Append resource (POST) allowed
     Given url requestUri


### PR DESCRIPTION
I found that we had a test that failed on NSS but worked on others because of different assumptions from the original. It would now relate to the semaphore mechanism, discussed in https://github.com/solid/specification/issues/322 and elsewhere. So, I created passing tests for this. 

This is not universally supported, so we might leave this as draft. It passes on NSS.