### PR TITLE
Bulk move uncontroversial tests to 'approve' review status

### DIFF
--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -27,28 +27,28 @@ manifest:authentication-header
   a td:TestCase ;
     spec:requirementReference sopr:server-authentication,
     sopr:server-unauthenticated ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/authentication/header.feature> .
 
 manifest:content-negotiation-turtle
   a td:TestCase ;
   spec:requirementReference sopr:server-representation-turtle-jsonld ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/content-negotiation/content-negotiation-turtle.feature> .
 
 manifest:content-negotiation-jsonld
   a td:TestCase ;
   spec:requirementReference sopr:server-representation-turtle-jsonld ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/content-negotiation/content-negotiation-jsonld.feature> .
 
 manifest:writing-resource-containment
   a td:TestCase ;
   spec:requirementReference sopr:server-put-patch-intermediate-containers ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/writing-resource/containment.feature> .
 

--- a/web-access-control/web-access-control-test-manifest.ttl
+++ b/web-access-control/web-access-control-test-manifest.ttl
@@ -10,7 +10,7 @@ prefix manifest: <#>
 manifest:protected-operation-not-read-resource-access-AWC
   a td:TestCase ;
   spec:requirementReference <https://solid.github.io/web-access-control-spec#access-modes> ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   td:preCondition "authentication", "acl" ;
   spec:testScript
     <https://github.com/solid/specification-tests/web-access-control/protected-operation/not-read-resource-access-AWC.feature> .
@@ -26,7 +26,7 @@ manifest:protected-operation-not-read-resource-default-AWC
 manifest:protected-operation-read-resource-access-R
   a td:TestCase ;
   spec:requirementReference <https://solid.github.io/web-access-control-spec#access-modes> ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   td:preCondition "authentication", "acl" ;
   spec:testScript
     <https://github.com/solid/specification-tests/web-access-control/protected-operation/read-resource-access-R.feature> .
@@ -34,7 +34,7 @@ manifest:protected-operation-read-resource-access-R
 manifest:protected-operation-read-resource-default-R
   a td:TestCase ;
   spec:requirementReference <https://solid.github.io/web-access-control-spec#access-modes> ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   td:preCondition "authentication", "acl" ;
   spec:testScript
     <https://github.com/solid/specification-tests/web-access-control/protected-operation/read-resource-default-R.feature> .
@@ -42,7 +42,7 @@ manifest:protected-operation-read-resource-default-R
 manifest:acl-object-none
   a td:TestCase ;
   spec:requirementReference <https://solid.github.io/web-access-control-spec#access-objects> ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   td:preCondition "authentication", "acl" ;
   spec:testScript
     <https://github.com/solid/specification-tests/web-access-control/acl-object/container-none.feature> .
@@ -50,7 +50,7 @@ manifest:acl-object-none
 manifest:acl-object-access-to
   a td:TestCase ;
   spec:requirementReference <https://solid.github.io/web-access-control-spec#access-objects> ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   td:preCondition "authentication", "acl" ;
   spec:testScript
     <https://github.com/solid/specification-tests/web-access-control/acl-object/container-access-to.feature> .
@@ -66,7 +66,7 @@ manifest:acl-object-default
 manifest:acl-object-access-to-default
   a td:TestCase ;
   spec:requirementReference <https://solid.github.io/web-access-control-spec#access-objects> ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   td:preCondition "authentication", "acl" ;
   spec:testScript
     <https://github.com/solid/specification-tests/web-access-control/acl-object/container-access-to-default.feature> .
@@ -74,7 +74,7 @@ manifest:acl-object-access-to-default
 manifest:protected-operation-acl-propagation
   a td:TestCase ;
   spec:requirementReference <https://solid.github.io/web-access-control-spec#authorization-evaluation-context> ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   td:preCondition "authentication", "acl" ;
   spec:testScript
     <https://github.com/solid/specification-tests/web-access-control/protected-operation/acl-propagation.feature> .
@@ -82,7 +82,7 @@ manifest:protected-operation-acl-propagation
 manifest:server-wac-allow-header-exists
   a td:TestCase ;
   spec:requirementReference <https://solid.github.io/web-access-control-spec#server-wac-allow> ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   td:preCondition "authentication", "acl";
   spec:testScript
     <https://github.com/solid/specification-tests/web-access-control/wac-allow/header-exists.feature> .
@@ -90,7 +90,7 @@ manifest:server-wac-allow-header-exists
 manifest:server-wac-allow-user-access-direct
   a td:TestCase ;
   spec:requirementReference <https://solid.github.io/web-access-control-spec#server-wac-allow> ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   td:preCondition "authentication", "acl";
   spec:testScript
     <https://github.com/solid/specification-tests/web-access-control/wac-allow/user-access-direct.feature> .
@@ -98,7 +98,7 @@ manifest:server-wac-allow-user-access-direct
 manifest:server-wac-allow-user-access-indirect
   a td:TestCase ;
   spec:requirementReference <https://solid.github.io/web-access-control-spec#server-wac-allow> ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   td:preCondition "authentication", "acl";
   spec:testScript
     <https://github.com/solid/specification-tests/web-access-control/wac-allow/user-access-indirect.feature> .
@@ -106,7 +106,7 @@ manifest:server-wac-allow-user-access-indirect
 manifest:server-wac-allow-public-access-direct
   a td:TestCase ;
   spec:requirementReference <https://solid.github.io/web-access-control-spec#server-wac-allow> ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   td:preCondition "authentication", "acl", "wac-allow-public";
   spec:testScript
     <https://github.com/solid/specification-tests/web-access-control/wac-allow/public-access-direct.feature> .
@@ -114,7 +114,7 @@ manifest:server-wac-allow-public-access-direct
 manifest:server-wac-allow-public-access-indirect
   a td:TestCase ;
   spec:requirementReference <https://solid.github.io/web-access-control-spec#server-wac-allow> ;
-  td:reviewStatus td:unreviewed ;
+  td:reviewStatus td:approved ;
   td:preCondition "authentication", "acl", "wac-allow-public";
   spec:testScript
     <https://github.com/solid/specification-tests/web-access-control/wac-allow/public-access-indirect.feature> .


### PR DESCRIPTION
Currently, all Conformance Test Suite tests are marked as 'unreviewed'. To reduce the overhead required from the Solid Editors to review and approve the tests, it was proposed that 'uncontroversial' tests could be bulk approved.

To determine the tests to 'approve', the Conformance Test Harness was executed against CSS, ESS (ACP & WAC), and NSS and the results analysed:

- If a test passed all servers, or passed most servers with expected failure on some servers (e.g., WAC-allow tests failed on ESS (ACP) as WAC-allow headers are not implemented), it is assumed the test is correct, and the review status was updated to 'approved'.
- If a test failed unexpectedly against any server, the review status was left as 'unreviewed'.

Note: The analysis has been deliberately not been included in this PR to avoid publishing test results related to individual Solid servers.