### PR TITLE
Add notes about versioning and a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Solid Specification Conformance Tests
+
+## Release 0.0.1
+Initial release of tests in the following areas:
+
+### Solid Protocol
+* Content-header for `PUT`, `POST`, `PATCH` requests.
+* Slash semantics.
+* Authentication header (approved).
+* Content negotiation (approved).
+* Creation of intermediate containers (approved).
+
+### Web Access Control
+* Access modes (some approved).
+* Access objects (some approved).
+* Evaluation context (approved).
+* WAC-Allow header (approved).
+
+### Converted tests
+* These are a set of tests that apply to some of the above areas but have neither been linked into specification 
+  requirements, nor reviewed. 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- MarkdownTOC -->
 
-- [Running these tests locally](#running-these-tests-locally)
+- [Running these tests locally](#run-script)
 - [KarateDSL](#karatedsl)
   - [Structure of a Test Case](#structure-of-a-test-case)
   - [Data related keywords](#data-related-keywords)
@@ -16,6 +16,7 @@
 - [Example Test Cases](#example-test-cases)
 - [Specification Annotations](#specification-annotations)
 - [Test Manifest](#test-manifest)
+- [Versioning](#versioning)
 
 <!-- /MarkdownTOC -->
 
@@ -1067,3 +1068,24 @@ manifest:acl-object-none
   spec:testScript
     <https://github.com/solid/specification-tests/web-access-control/acl-object/container-none.feature> .
 ```
+
+# Versioning
+This repository will tag releases to make it possible to track report results to the specific versions of tests that were
+run. Changes to the tests for each version will be described in the [CHANGELOG.md](CHANGELOG.md).
+
+The release process is:
+* Check that any relevant PRs have been merged and pulled locally.
+* Update CHANGELOG.md to describe changes since the last release.
+* Tag the repository (the message is optional):
+  ```shell
+  git tag -a v1.0.0 -m "Releasing version v1.0.0"
+  ```
+* Commit the CHANGELOG and push it with the tags:
+  ```shell
+  git push origin --tags
+  ```
+* Create the release in GitHub - [Create a new release](https://github.com/solid/specification-tests/releases/new):
+  * Choose the tag that was just created.
+  * Add a title, e.g. `Release 1.0.0`.
+  * Add some content describing notable changes.
+  * Publish the release.


### PR DESCRIPTION
If this PR is OK, then I propose to set the repo to v0.0.1. Then I can work on how the you can run CTH with a specific version of tests, pass that version number into reports and determine if the version is the latest.