### PR TITLE
Test that intermediate containers are created

### DIFF
--- a/protocol/converted.ttl
+++ b/protocol/converted.ttl
@@ -24,14 +24,6 @@ manifest:converted-test1-3
     <https://github.com/solid/specification-tests/protocol/converted/test_1-3.feature> ;
   dcterms:description "Update: PUT Turtle resources to container with varying LDP Interaction Models."@en .
 
-manifest:converted-test1-4
-  a td:TestCase ;
-#  spec:requirementReference sopr:resource-representations ;
-  td:reviewStatus td:unreviewed ;
-  spec:testScript
-    <https://github.com/solid/specification-tests/protocol/converted/test_1-4.feature> ;
-  dcterms:description "Create: PUT Turtle resources to into a deep hierarchy."@en .
-
 manifest:converted-test1-5
   a td:TestCase ;
 #  spec:requirementReference sopr:resource-representations ;

--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -62,7 +62,7 @@ manifest:writing-resource-containment
 
 manifest:deep-hierarchy
   a td:TestCase ;
-  spec:requirementReference sopr:server-hierarchical-containment ;
+  spec:requirementReference sopr:server-put-patch-intermediate-containers ;
   td:reviewStatus td:unreviewed ;
   spec:testScript
-    <https://github.com/solid/specification-tests/protocol/converted/deep-hierarchy.feature> .
+    <https://github.com/solid/specification-tests/protocol/writing-resource/deep-hierarchy.feature> .

--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -59,3 +59,10 @@ manifest:writing-resource-containment
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/writing-resource/containment.feature> .
 
+
+manifest:deep-hierarchy
+  a td:TestCase ;
+  spec:requirementReference sopr:server-hierarchical-containment ;
+  td:reviewStatus td:unreviewed ;
+  spec:testScript
+    <https://github.com/solid/specification-tests/protocol/converted/deep-hierarchy.feature> .

--- a/protocol/writing-resource/deep-hierarchy.feature
+++ b/protocol/writing-resource/deep-hierarchy.feature
@@ -3,31 +3,7 @@ Feature: Create: PUT Turtle resources to into a deep hierarchy.
   Background: Setup
     * def testContainer = createTestContainerImmediate()
 
-  Scenario: Test 4.1 Conflict creating /foo/bar/dahut-bc.ttl as a container
-    * def requestUri = testContainer.getUrl() + 'foo/bar/dahut-bc.ttl'
-    Given url requestUri
-    And configure headers = clients.alice.getAuthHeaders('PUT', requestUri)
-    And header Content-Type = 'text/turtle'
-    And header Link = '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"'
-    And request '@prefix dc: <http://purl.org/dc/terms/>. <> dc:title "Container Interaction Model"@en .'
-    When method PUT
-    Then status 409
-
-    # Test 4.2 Resource should not have been creaed
-    * def requestUri = testContainer.getUrl() + 'foo/bar/dahut-bc.ttl'
-    Given url requestUri
-    And configure headers = clients.alice.getAuthHeaders('GET', requestUri)
-    When method GET
-    Then status 404
-
-    # Test 4.3 No container created: /foo
-    * def requestUri = testContainer.getUrl() + 'foo'
-    Given url requestUri
-    And configure headers = clients.alice.getAuthHeaders('GET', requestUri)
-    When method GET
-    Then status 404
-
-  Scenario: Test 4.4 Create RDFSource at /foo/baz/dahut-rs.ttl
+  Scenario: Create RDFSource at /foo/baz/dahut-rs.ttl
     * def requestUri = testContainer.getUrl() + 'foo/baz/dahut-rs.ttl'
     Given url requestUri
     And configure headers = clients.alice.getAuthHeaders('PUT', requestUri)
@@ -35,7 +11,7 @@ Feature: Create: PUT Turtle resources to into a deep hierarchy.
     And header Link = '<http://www.w3.org/ns/ldp#RDFSource>; rel="type"'
     And request '@prefix dc: <http://purl.org/dc/terms/>. <> dc:title "RDF source Interaction Model"@en .'
     When method PUT
-    Then match [200, 201, 204, 205] contains responseStatus
+    Then status 201
 
     # Test 4.5 Check resource exists: /foo/baz/dahut-rs.ttl
     Given url requestUri
@@ -50,14 +26,14 @@ Feature: Create: PUT Turtle resources to into a deep hierarchy.
     When method GET
     Then status 200
 
-  Scenario: Test 4.7 Create No Interaction model resource at /foobar/baz/dahut-no.ttl
+  Scenario: Create No Interaction model resource at /foobar/baz/dahut-no.ttl
     * def requestUri = testContainer.getUrl() + 'foobar/baz/dahut-no.ttl'
     Given url requestUri
     And configure headers = clients.alice.getAuthHeaders('PUT', requestUri)
     And header Content-Type = 'text/turtle'
     And request '@prefix dc: <http://purl.org/dc/terms/>. <> dc:title "No Interaction Model"@en .'
     When method PUT
-    Then match [200, 201, 204, 205] contains responseStatus
+    Then status 201
 
     # Test 4.8 Check resource exists /foobar/baz/dahut-no.ttl
     * def requestUri = testContainer.getUrl() + 'foobar/baz/dahut-no.ttl'
@@ -65,7 +41,6 @@ Feature: Create: PUT Turtle resources to into a deep hierarchy.
     And configure headers = clients.alice.getAuthHeaders('GET', requestUri)
     When method GET
     Then status 200
-    # TODO Would the link header show RDFSource
 
   # Test 4.9 Check container exists: /foobar/
     * def requestUri = testContainer.getUrl() + 'foobar/'

--- a/protocol/writing-resource/deep-hierarchy.feature
+++ b/protocol/writing-resource/deep-hierarchy.feature
@@ -13,18 +13,21 @@ Feature: Create: PUT Turtle resources to into a deep hierarchy.
     When method PUT
     Then status 201
 
-    # Test 4.5 Check resource exists: /foo/baz/dahut-rs.ttl
+    # Check resource exists: /foo/baz/dahut-rs.ttl
     Given url requestUri
     And configure headers = clients.alice.getAuthHeaders('GET', requestUri)
     When method GET
     Then status 200
+    * match response contains 'source Interaction'
 
-    # Test 4.6 Check container exists: /foo/
+    # Check container exists: /foo/
     * def requestUri = testContainer.url + 'foo/'
     Given url requestUri
     And configure headers = clients.alice.getAuthHeaders('GET', requestUri)
     When method GET
     Then status 200
+    # TODO: We should be matching triples here
+    * match response contains 'contains'
 
   Scenario: Create No Interaction model resource at /foobar/baz/dahut-no.ttl
     * def requestUri = testContainer.url + 'foobar/baz/dahut-no.ttl'
@@ -35,16 +38,19 @@ Feature: Create: PUT Turtle resources to into a deep hierarchy.
     When method PUT
     Then status 201
 
-    # Test 4.8 Check resource exists /foobar/baz/dahut-no.ttl
+    # Check resource exists /foobar/baz/dahut-no.ttl
     * def requestUri = testContainer.url + 'foobar/baz/dahut-no.ttl'
     Given url requestUri
     And configure headers = clients.alice.getAuthHeaders('GET', requestUri)
     When method GET
     Then status 200
+    * match response contains 'No Interaction Model'
 
-  # Test 4.9 Check container exists: /foobar/
+    # Check container exists: /foobar/
     * def requestUri = testContainer.url + 'foobar/'
     Given url requestUri
     And configure headers = clients.alice.getAuthHeaders('GET', requestUri)
     When method GET
     Then status 200
+    # TODO: We should be matching triples here
+    * match response contains 'contains'

--- a/protocol/writing-resource/deep-hierarchy.feature
+++ b/protocol/writing-resource/deep-hierarchy.feature
@@ -4,7 +4,7 @@ Feature: Create: PUT Turtle resources to into a deep hierarchy.
     * def testContainer = createTestContainerImmediate()
 
   Scenario: Create RDFSource at /foo/baz/dahut-rs.ttl
-    * def requestUri = testContainer.getUrl() + 'foo/baz/dahut-rs.ttl'
+    * def requestUri = testContainer.url + 'foo/baz/dahut-rs.ttl'
     Given url requestUri
     And configure headers = clients.alice.getAuthHeaders('PUT', requestUri)
     And header Content-Type = 'text/turtle'
@@ -20,14 +20,14 @@ Feature: Create: PUT Turtle resources to into a deep hierarchy.
     Then status 200
 
     # Test 4.6 Check container exists: /foo/
-    * def requestUri = testContainer.getUrl() + 'foo/'
+    * def requestUri = testContainer.url + 'foo/'
     Given url requestUri
     And configure headers = clients.alice.getAuthHeaders('GET', requestUri)
     When method GET
     Then status 200
 
   Scenario: Create No Interaction model resource at /foobar/baz/dahut-no.ttl
-    * def requestUri = testContainer.getUrl() + 'foobar/baz/dahut-no.ttl'
+    * def requestUri = testContainer.url + 'foobar/baz/dahut-no.ttl'
     Given url requestUri
     And configure headers = clients.alice.getAuthHeaders('PUT', requestUri)
     And header Content-Type = 'text/turtle'
@@ -36,14 +36,14 @@ Feature: Create: PUT Turtle resources to into a deep hierarchy.
     Then status 201
 
     # Test 4.8 Check resource exists /foobar/baz/dahut-no.ttl
-    * def requestUri = testContainer.getUrl() + 'foobar/baz/dahut-no.ttl'
+    * def requestUri = testContainer.url + 'foobar/baz/dahut-no.ttl'
     Given url requestUri
     And configure headers = clients.alice.getAuthHeaders('GET', requestUri)
     When method GET
     Then status 200
 
   # Test 4.9 Check container exists: /foobar/
-    * def requestUri = testContainer.getUrl() + 'foobar/'
+    * def requestUri = testContainer.url + 'foobar/'
     Given url requestUri
     And configure headers = clients.alice.getAuthHeaders('GET', requestUri)
     When method GET


### PR DESCRIPTION
These tests is to incorporate older converted tests. They are adapted and cleaned up, but it leaves some to be desired, like testing actual triples, and doing it for `PATCH` too.