### PR TITLE
URI Assignment with PUT and PATCH

### DIFF
--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -52,6 +52,13 @@ manifest:content-negotiation-jsonld
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/content-negotiation/content-negotiation-jsonld.feature> .
 
+manifest:uri-assignment
+  a td:TestCase ;
+  spec:requirementReference sopr:server-put-patch-uri-assignment ;
+  td:reviewStatus td:unreviewed ;
+  spec:testScript
+    <https://github.com/solid/specification-tests/protocol/writing-resource/uri-assignment.feature> .
+
 manifest:writing-resource-containment
   a td:TestCase ;
   spec:requirementReference sopr:server-put-patch-intermediate-containers ;

--- a/protocol/writing-resource/uri-assignment.feature
+++ b/protocol/writing-resource/uri-assignment.feature
@@ -18,7 +18,7 @@ Feature: Server assigns URI based on effective request URI
     Then status 200
 
   @ignore  
-  Scenario: Create resource at /PATCH-dahut with PATCH
+  Scenario: Create resource at /patch-dahut with PATCH
     * def requestUri = testContainer.url + 'patch-dahut'
     Given url requestUri
     And configure headers = clients.alice.getAuthHeaders('PATCH', requestUri)

--- a/protocol/writing-resource/uri-assignment.feature
+++ b/protocol/writing-resource/uri-assignment.feature
@@ -1,0 +1,35 @@
+Feature: Server assigns URI based on effective request URI
+
+  Background: Setup
+    * def testContainer = createTestContainerImmediate()
+
+  Scenario: Create resource at /put-dahut with PUT
+    * def requestUri = testContainer.url + 'put-dahut'
+    Given url requestUri
+    And configure headers = clients.alice.getAuthHeaders('PUT', requestUri)
+    And header Content-Type = 'text/turtle'
+    And request '@prefix dc: <http://purl.org/dc/terms/>. <> dc:title "Create resource without suffix"@en .'
+    When method PUT
+    Then status 201
+
+    Given url requestUri
+    And configure headers = clients.alice.getAuthHeaders('GET', requestUri)
+    When method GET
+    Then status 200
+
+  @ignore  
+  Scenario: Create resource at /PATCH-dahut with PATCH
+    * def requestUri = testContainer.url + 'patch-dahut'
+    Given url requestUri
+    And configure headers = clients.alice.getAuthHeaders('PATCH', requestUri)
+    And header Content-Type = 'text/n3'
+    And request '@prefix solid: <http://www.w3.org/ns/solid/terms#>. @prefix dc: <http://purl.org/dc/terms/>. _:insert a solid:Patch ; solid:inserts { <> dc:title "Create resource without suffix"@en . } .'
+    When method PATCH
+    Then status 201
+
+    Given url requestUri
+    And configure headers = clients.alice.getAuthHeaders('GET', requestUri)
+    When method GET
+    Then status 200
+
+


### PR DESCRIPTION
This is focused on the requirement URI assignment using `PUT` and `PATCH`. The `PUT` test should be OK, but for the `PATCH`, it needs to go in after the merge of https://github.com/solid/specification/pull/346 I'm also not 100% sure about the syntax, so it should be reviewed for that too. I've added an `@ignore` tag for that reason.