### PR TITLE
Test for presence of at most one describedby link

### DIFF
--- a/protocol/resources/describedby-unique.feature
+++ b/protocol/resources/describedby-unique.feature
@@ -16,4 +16,4 @@ Feature: Server may link to one description resource
     When method GET
     * def links = parseLinkHeaders(responseHeaders)
     * def test = links.filter(el => el.rel === 'describedBy')
-    And assert (test.length <= 1)
+    Then assert (test.length <= 1)

--- a/protocol/resources/describedby-unique.feature
+++ b/protocol/resources/describedby-unique.feature
@@ -9,3 +9,11 @@ Feature: Server must link to exactly one description resource
     * def links = parseLinkHeaders(responseHeaders)
     * def test = links.filter(el => el.rel === 'describedBy')
     And assert (test.length === 1)
+
+  Scenario: Server sees exactly one Link to description resource from RDF resource
+    * def resource = testContainer.createResource('.ttl', '', 'text/turtle')
+    Given url resource.url
+    When method GET
+    * def links = parseLinkHeaders(responseHeaders)
+    * def test = links.filter(el => el.rel === 'describedBy')
+    And assert (test.length === 1)

--- a/protocol/resources/describedby-unique.feature
+++ b/protocol/resources/describedby-unique.feature
@@ -1,19 +1,19 @@
-Feature: Server must link to exactly one description resource 
+Feature: Server may link to one description resource 
 
   Background: Set up clients and paths
     * def testContainer = rootTestContainer.createContainer()
     
-  Scenario: Server sees exactly one Link to description resource from container
+  Scenario: Server sees at most one Link to description resource from container
     Given url testContainer.url
     When method GET
     * def links = parseLinkHeaders(responseHeaders)
     * def test = links.filter(el => el.rel === 'describedBy')
-    And assert (test.length === 1)
+    And assert (test.length <= 1)
 
-  Scenario: Server sees exactly one Link to description resource from RDF resource
+  Scenario: Server sees at most one Link to description resource from RDF resource
     * def resource = testContainer.createResource('.ttl', '', 'text/turtle')
     Given url resource.url
     When method GET
     * def links = parseLinkHeaders(responseHeaders)
     * def test = links.filter(el => el.rel === 'describedBy')
-    And assert (test.length === 1)
+    And assert (test.length <= 1)

--- a/protocol/resources/describedby-unique.feature
+++ b/protocol/resources/describedby-unique.feature
@@ -8,7 +8,7 @@ Feature: Server may link to one description resource
     When method GET
     * def links = parseLinkHeaders(responseHeaders)
     * def test = links.filter(el => el.rel === 'describedBy')
-    And assert (test.length <= 1)
+    Then assert (test.length <= 1)
 
   Scenario: Server sees at most one Link to description resource from RDF resource
     * def resource = testContainer.createResource('.ttl', '', 'text/turtle')

--- a/protocol/resources/describedby-unique.feature
+++ b/protocol/resources/describedby-unique.feature
@@ -1,0 +1,11 @@
+Feature: Server must link to exactly one description resource 
+
+  Background: Set up clients and paths
+    * def testContainer = rootTestContainer.createContainer()
+    
+  Scenario: Server sees exactly one Link to description resource from container
+    Given url testContainer.url
+    When method GET
+    * def links = parseLinkHeaders(responseHeaders)
+    * def test = links.filter(el => el.rel === 'describedBy')
+    And assert (test.length === 1)

--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -68,3 +68,10 @@ manifest:writing-resource-containment
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/writing-resource/containment.feature> .
 
+manifest:describedby-unique
+  a td:TestCase ;
+    spec:requirementReference sopr:server-description-resource-max ;
+  td:reviewStatus td:unreviewed ;
+  spec:testScript
+    <https://github.com/solid/specification-tests/protocol/resources/describedby-unique.feature> .
+


### PR DESCRIPTION
The intention here is to test for the presence of at most one describedby link. 

NSS will always have exactly one link, and that's required for discovering the feature, but the spec says nothing to require it. So, I made a last commit to relax that.