### PR TITLE
Non-working test for method not allowed

### DIFF
--- a/protocol/read-write-resource/method-not-allowed.feature
+++ b/protocol/read-write-resource/method-not-allowed.feature
@@ -1,0 +1,12 @@
+Feature: Respond with 405 for non-existent method
+
+  Background: Set up clients and paths
+    * def testContainer = rootTestContainer.createContainer()
+    * def resource = testContainer.createResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
+    
+  Scenario: Check response for DAHU method on container
+    * def response = clients.alice.sendAuthorized('DAHU', resource.url, null, null)
+    Then assert response.status == 405
+
+
+    # TODO: Iterate over list of known and unknown methods, check Allow header, and test the resulting set.

--- a/protocol/read-write-resource/method-not-allowed.feature
+++ b/protocol/read-write-resource/method-not-allowed.feature
@@ -7,6 +7,7 @@ Feature: Respond with 405 for non-existent method
   Scenario: Check response for DAHU method on container
     * def response = clients.alice.sendAuthorized('DAHU', resource.url, null, null)
     Then assert response.status == 405
+    And assert response.headers.allow != null
 
 
     # TODO: Iterate over list of known and unknown methods, check Allow header, and test the resulting set.

--- a/protocol/read-write-resource/method-not-allowed.feature
+++ b/protocol/read-write-resource/method-not-allowed.feature
@@ -4,8 +4,13 @@ Feature: Respond with 405 for non-existent method
     * def testContainer = rootTestContainer.createContainer()
     * def resource = testContainer.createResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
     
-  Scenario: Check response for DAHU method on container
+  Scenario: Check response for DAHU method on resource
     * def response = clients.alice.sendAuthorized('DAHU', resource.url, null, null)
+    Then assert response.status == 405
+    And assert response.headers.allow != null
+
+  Scenario: Check response for DAHU method on container
+    * def response = clients.alice.sendAuthorized('DAHU', testContainer.url, null, null)
     Then assert response.status == 405
     And assert response.headers.allow != null
 

--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -75,3 +75,10 @@ manifest:describedby-unique
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/resources/describedby-unique.feature> .
 
+manifest:method-not-allowed
+  a td:TestCase ;
+    spec:requirementReference sopr:server-method-not-allowed ;
+  td:reviewStatus td:unreviewed ;
+  spec:testScript
+    <https://github.com/solid/specification-tests/protocol/read-write-resource/method-not-allowed.feature> .
+


### PR DESCRIPTION
Here's an attempt to use the new `sendAuthorized` method in the harness. I get the following error though:

```
org.graalvm.polyglot.PolyglotException: TypeError: invokeMember (sendAuthorized) on org.solid.testharness.api.SolidClient@4e52d2f2 failed due to: Unknown identifier: sendAuthorized
```
I don't know if this means that I somehow haven't gotten the harness updated here, or if there's something wrong in the setup. So, I just made this so that I can work on other things while we check that our.