### PR TITLE
PUT or PATCH on auxiliary resources

### DIFF
--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -96,3 +96,10 @@ manifest:slug-uri-assignment
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/read-write-resource/post-uri-assignment-slug.feature> .
 
+manifest:put-patch-auxiliary-resource
+  a td:TestCase ;
+    spec:requirementReference sopr:server-put-patch-auxiliary-resource ;
+  td:reviewStatus td:unreviewed ;
+  spec:testScript
+    <https://github.com/solid/specification-tests/protocol/writing-resource/put-patch-auxiliary-resource.feature> .
+

--- a/protocol/writing-resource/put-patch-auxiliary-resource.feature
+++ b/protocol/writing-resource/put-patch-auxiliary-resource.feature
@@ -13,7 +13,7 @@ Feature: PUT or PATCH on auxiliary resources
     * def metaUrl = resolveUri(container.url, describedby.uri)
     Given url metaUrl
     And headers clients.alice.getAuthHeaders('PUT', metaUrl)
-    And header Content-Type = ''
+    And header Content-Type = 'text/turtle'
     And request "<> a <#Something> ."
     When method PUT
     Then status 201

--- a/protocol/writing-resource/put-patch-auxiliary-resource.feature
+++ b/protocol/writing-resource/put-patch-auxiliary-resource.feature
@@ -1,0 +1,19 @@
+Feature: PUT or PATCH on auxiliary resources
+
+  Background: Set up container and parse link headers
+    * def testContainer = rootTestContainer.createContainer()
+    * def container = testContainer.createContainer()  
+    * def exampleTurtle = karate.readAsString('../fixtures/example.ttl')
+    * def rdfResource = testContainer.createResource('.ttl', exampleTurtle, 'text/turtle');
+
+  Scenario: PUT auxiliary resource to container
+    * def response = clients.alice.sendAuthorized('GET', container.url, null, null)
+    * def links = parseLinkHeaders(response.headers)
+    * def describedby = links.find(el => el.rel === 'describedBy')
+    * def metaUrl = resolveUri(container.url, describedby.uri)
+    Given url metaUrl
+    And headers clients.alice.getAuthHeaders('PUT', metaUrl)
+    And header Content-Type = ''
+    And request "<> a <#Something> ."
+    When method PUT
+    Then status 201

--- a/protocol/writing-resource/put-patch-auxiliary-resource.feature
+++ b/protocol/writing-resource/put-patch-auxiliary-resource.feature
@@ -14,6 +14,6 @@ Feature: PUT or PATCH on auxiliary resources
     Given url metaUrl
     And headers clients.alice.getAuthHeaders('PUT', metaUrl)
     And header Content-Type = 'text/turtle'
-    And request "<> a <#Something> ."
+    And request "<./> a <#Something> ."
     When method PUT
     Then status 201


### PR DESCRIPTION
The following test looks correct to me, but all three servers fail, so I guess not... 

CSS and ESS does not appear to support description resources (and they not appear to be required by the spec, which may be an omission).

NSS fails with the following:

```