### PR TITLE
Protecting containment triples

### DIFF
--- a/protocol/solid-protocol-test-manifest.ttl
+++ b/protocol/solid-protocol-test-manifest.ttl
@@ -96,3 +96,10 @@ manifest:slug-uri-assignment
   spec:testScript
     <https://github.com/solid/specification-tests/protocol/read-write-resource/post-uri-assignment-slug.feature> .
 
+manifest:protect-containment
+  a td:TestCase ;
+    spec:requirementReference sopr:server-protect-containment ;
+  td:reviewStatus td:unreviewed ;
+  spec:testScript
+    <https://github.com/solid/specification-tests/protocol/writing-resource/protect-containment.feature> .
+

--- a/protocol/writing-resource/protect-containment.feature
+++ b/protocol/writing-resource/protect-containment.feature
@@ -1,0 +1,19 @@
+Feature: Server protects containment triples
+  
+  Background: Set up container and a few child resources
+    * def testContainer = rootTestContainer.createContainer()
+    * def exampleTurtle = karate.readAsString('../fixtures/example.ttl')
+    * def resource1 = testContainer.createResource('.ttl', exampleTurtle, 'text/turtle');
+    * def resource2 = testContainer.createResource('.txt', 'DAHUT', 'text/plain');
+    * def resource3 = testContainer.createResource('.txt', 'FOOBAR', 'text/plain');
+    * def container1 = testContainer.createContainer()   
+    * def children = [ resource1.url, resource2.url, resource3.url, container1.url ]
+    
+  Scenario: Check that members are correct
+    Given url testContainer.url
+    And headers clients.alice.getAuthHeaders('GET', testContainer.url)
+    When method GET
+    Then status 200
+    * def contained = parse(response, 'text/turtle', testContainer.url).members 
+    And match contained contains only children
+    And match children contains only contained


### PR DESCRIPTION
Here's an initial attempt at tests to protect containment triples, but it doesn't work. I'm trying to construct an array of the URLs with 
```gherkin
    * def children = [ resource1.url, resource2.url, resource3.url, container1.url ]
```
but it seems to take that literally, because when I run the test, I get

```
  $ | actual does not contain expected | actual array does not contain expected item - resource1.url (LIST:LIST)
  ["https://solid-test-suite-alice.inrupt.net/shared-test/m98a02/yzyRp5/30Ax9A.txt","https://solid-test-suite-alice.inrupt.net/shared-test/m98a02/yzyRp5/30nN0E.txt","https://solid-test-suite-alice.inrupt.net/shared-test/m98a02/yzyRp5/3pjnp7/","https://solid-test-suite-alice.inrupt.net/shared-test/m98a02/yzyRp5/mpQypr.ttl"]
  ["resource1.url","resource2.url","resource3.url","container1.url"]
```
so, it seems it takes the variables as literals.


I have also tried
```gherkin
    * def children = []
    * def children[0] = resource1.url
    * def children[1] = resource2.url
    * def children[2] = resource3.url
    * def children[3] = container1.url
```

but then I get
```
no step-definition method match found for: def children[0] = resource1.url
../data/protocol/writing-resource/protect-containment.feature:11
```
