### PR TITLE
Document additional version param on send method

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ of the `SolidClient`. The map can be applied to a request being prepared in Kara
   * url - The absolute url of the request.
 * Returns a map of headers.
 
-#### `send(method, uri, data, headers)` and `sendAuthorized(method, uri, data, headers)`
+#### `send(method, uri, data, headers, version)` and `sendAuthorized(method, uri, data, headers, version)`
 This is an alternative way to send a request which allows testers to have full control over the HTTP method and request
 headers. Karate will not allow invalid HTTP methods and sets some headers by default so this method allows some
 additional edge case tests to be performed. The only request header these methods include by default is the `User-Agent`
@@ -641,9 +641,11 @@ requests, whereas the second adds the correct authorization headers for the user
   * url - The absolute url of the request.
   * data - The data to be sent in the request (or null). 
   * headers - A map of key/value pairs to be send as request headers (or null). See the note below for additional tips.
+  * version - The version of HTTP to use for the request "HTTP_1_1" or "HTTP_2".
 * Returns the response as a map with the following structure:
   ```json5
   {
+    version: "HTTP_1_1", // string (or HTTP_2 depending on which the server responded with)
     status: 200, // integer
     headers: {}, // map of all response headers
     body: "",    // the response body

--- a/protocol/read-write-resource/method-not-allowed.feature
+++ b/protocol/read-write-resource/method-not-allowed.feature
@@ -3,14 +3,14 @@ Feature: Respond with 405 for non-existent method
   Background: Set up clients and paths
     * def testContainer = rootTestContainer.createContainer()
     * def resource = testContainer.createResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
-    
+
   Scenario: Check response for DAHU method on resource
-    * def response = clients.alice.sendAuthorized('DAHU', resource.url, null, null)
+    * def response = clients.alice.sendAuthorized('DAHU', resource.url, null, null, 'HTTP_1_1')
     Then assert response.status == 405
     And assert response.headers.allow != null
 
   Scenario: Check response for DAHU method on container
-    * def response = clients.alice.sendAuthorized('DAHU', testContainer.url, null, null)
+    * def response = clients.alice.sendAuthorized('DAHU', testContainer.url, null, null, 'HTTP_1_1')
     Then assert response.status == 405
     And assert response.headers.allow != null
 

--- a/web-access-control/protected-operation/read-resource-access-R.feature
+++ b/web-access-control/protected-operation/read-resource-access-R.feature
@@ -53,5 +53,5 @@ Feature: Bob can only read an RDF resource to which he is only granted read acce
     Then status 403
 
   Scenario: Bob cannot use an unknown method on the resource
-    * def response = clients.alice.sendAuthorized('DAHU', resource.url, null, null)
+    * def response = clients.bob.sendAuthorized('DAHU', resource.url, null, null, 'HTTP_1_1')
     Then assert response.status == 405


### PR DESCRIPTION
You can now set the preferred HTTP version.

This means we can now test whether a server supports HTTP/2 e.g.
```
Scenario: Server supports HTTP/2
    * def response = clients.alice.sendAuthorized('GET', resource.url, null, null, 'HTTP_2')
    Then assert response.status == 200
    And assert response.version == 'HTTP_2'
```
However, note that this is a `SHOULD` so we may need to improve the report to avoid making the test failure look like a requirement failure.