### PR TITLE
Remove the DAHU test

### DIFF
--- a/protocol/read-write-resource/method-not-allowed.feature
+++ b/protocol/read-write-resource/method-not-allowed.feature
@@ -1,18 +1,19 @@
-Feature: Respond with 405 for non-existent method
+Feature: Error for undefined method
 
   Background: Set up clients and paths
     * def testContainer = rootTestContainer.createContainer()
     * def resource = testContainer.createResource('.ttl', karate.readAsString('../fixtures/example.ttl'), 'text/turtle');
 
-  Scenario: Check response for DAHU method on resource
-    * def response = clients.alice.sendAuthorized('DAHU', resource.url, null, null, 'HTTP_1_1')
-    Then assert response.status == 405
-    And assert response.headers.allow != null
+  Scenario: Check response for TRACE method on resource
+    * def response = clients.alice.sendAuthorized('TRACE', resource.url, null, null, null)
+    Then assert response.status == 400 || response.status == 405 || response.status == 501
+#    And assert response.headers.allow != null
 
-  Scenario: Check response for DAHU method on container
-    * def response = clients.alice.sendAuthorized('DAHU', testContainer.url, null, null, 'HTTP_1_1')
-    Then assert response.status == 405
-    And assert response.headers.allow != null
+  Scenario: Check response for TRACE method on container
+    * def response = clients.alice.sendAuthorized('TRACE', testContainer.url, null, null, null)
+    Then assert response.status == 400 || response.status == 405 || response.status == 501
+#    And assert response.headers.allow != null
 
+    # TODO: Test that Allow is present when 405 is returned
 
     # TODO: Iterate over list of known and unknown methods, check Allow header, and test the resulting set.

--- a/protocol/read-write-resource/method-not-allowed.feature
+++ b/protocol/read-write-resource/method-not-allowed.feature
@@ -11,7 +11,7 @@ Feature: Error for unsupported method
 
   Scenario: Check response for TRACE method on container
     * def response = clients.alice.sendAuthorized('TRACE', testContainer.url, null, null, null)
-    Then assert response.status == 400 || response.status == 405 || response.status == 501
+    Then match [400, 405, 501] contains response.status
 #    And assert response.headers.allow != null
 
     # TODO: Test that Allow is present when 405 is returned

--- a/protocol/read-write-resource/method-not-allowed.feature
+++ b/protocol/read-write-resource/method-not-allowed.feature
@@ -1,4 +1,4 @@
-Feature: Error for undefined method
+Feature: Error for unsupported method
 
   Background: Set up clients and paths
     * def testContainer = rootTestContainer.createContainer()

--- a/protocol/read-write-resource/method-not-allowed.feature
+++ b/protocol/read-write-resource/method-not-allowed.feature
@@ -6,7 +6,7 @@ Feature: Error for unsupported method
 
   Scenario: Check response for TRACE method on resource
     * def response = clients.alice.sendAuthorized('TRACE', resource.url, null, null, null)
-    Then assert response.status == 400 || response.status == 405 || response.status == 501
+    Then match [400, 405, 501] contains response.status
 #    And assert response.headers.allow != null
 
   Scenario: Check response for TRACE method on container


### PR DESCRIPTION
Following https://github.com/solid/conformance-test-harness/issues/155 I'm proposing the remove the corner case evil `DAHU` method test to. Instead, this has a `TRACE` test, which is in HTTP but not in Solid. 

Unfortunately, it is hard to have a conditional test now, and previously, I also checked the `Allow` header as that should be on every `405` but with this variability, it is hard to do, so I removed it for now.