### PR TITLE
Improve run.sh to pass user to docker

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -118,7 +118,7 @@ then
 fi
 
 dockerimage='solidproject/conformance-test-harness'
-dockerargs=('-i' '--rm')
+dockerargs=('-i' '--rm' '--user' "$(id -u):$(id -g)")
 cwd=$(pwd)
 harnessargs=('--output=/reports')
 
@@ -174,8 +174,9 @@ if ! [[ "$*" == *"--target="* ]]; then
   harnessargs+=("--target=https://github.com/solid/conformance-test-harness/$subject")
 fi
 
-# ensure report directory exists
+# ensure report and target directories exist
 mkdir -p reports/$subject
+mkdir -p target
 
 # optionally start CSS
 if [ $subject == "css" ]


### PR DESCRIPTION
Testing was failing with WSL as docker used the root user so this passes in the current user. It also creates the target directory in advance so it has the user's permission